### PR TITLE
fix: correctly install custom version of vmdb2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ RUN apt update \
 ENV LANG   en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-RUN wget https://github.com/glattercj/vmdb2/releases/download/v1.1/vmdb2 -P /usr/bin/ \
+RUN wget https://github.com/glattercj/vmdb2/releases/download/v1.1/vmdb2 -O /usr/bin/vmdb2 \
   && chmod +x /usr/bin/vmdb2
 
 # do this before installing phenix-apps so minimega package is latest version


### PR DESCRIPTION
Commit e0678ad included moving the installation of our custom version of vmdb2 to the final Docker image target in docker/Dockerfile. We needed to use the -O option instead of the -P option to make sure the existing vmdb2 installed via apt (to pull in the required dependency packages) was truly overwritten.

fixes #137