### PR TITLE
fix: specify src and dst image formats when rebasing new backing image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ RUN apt update \
 ENV LANG   en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-RUN wget https://github.com/glattercj/vmdb2/releases/download/v1.1/vmdb2 -P /usr/bin/ \
+RUN wget https://github.com/glattercj/vmdb2/releases/download/v1.1/vmdb2 -O /usr/bin/vmdb2 \
   && chmod +x /usr/bin/vmdb2
 
 # do this before installing phenix-apps so minimega package is latest version

--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -1048,7 +1048,7 @@ func CommitToDisk(expName, vmName, out string, cb func(float64)) (string, error)
 
 	snap = fmt.Sprintf("%s/images/%s/tmp/%s.qc2", common.PhenixBase, expName, vmName)
 
-	shell := exec.Command("qemu-img", "rebase", "-b", out, snap)
+	shell := exec.Command("qemu-img", "rebase", "-f", "qcow2", "-b", out, "-F", "qcow2", snap)
 
 	res, err := shell.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Recent(ish) updates to qemu-img now require specification of image formats. This became an issue when the base Docker image was upgraded to 22.04 in e0678ad.