### PR TITLE
Disable scenario apps during experiment creation

### DIFF
--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -23,6 +23,7 @@ import (
 	"phenix/util/mm"
 	"phenix/util/mm/mmcli"
 	"phenix/util/notes"
+	"phenix/util/plog"
 	"phenix/util/pubsub"
 
 	"github.com/activeshadow/structs"
@@ -212,6 +213,10 @@ func Create(ctx context.Context, opts ...CreateOption) error {
 		"topology":       topo,
 	}
 
+	if o.disabledApps != nil {
+		plog.Info(fmt.Sprintf("Got disabled applications: %v", o.disabledApps))
+	}
+
 	if o.scenario != "" {
 		scenarioC, _ := store.NewConfig("scenario/" + o.scenario)
 
@@ -229,7 +234,8 @@ func Create(ctx context.Context, opts ...CreateOption) error {
 		}
 
 		// This will upgrade the scenario to the latest known version if needed.
-		scenario, err := types.DecodeScenarioFromConfig(*scenarioC)
+		plog.Info("Creating custom scenario")
+		scenario, err := types.MakeCustomScenarioFromConfig(*scenarioC, o.disabledApps)
 		if err != nil {
 			return fmt.Errorf("decoding scenario from config: %w", err)
 		}

--- a/src/go/api/experiment/option.go
+++ b/src/go/api/experiment/option.go
@@ -8,15 +8,16 @@ import (
 type CreateOption func(*createOptions)
 
 type createOptions struct {
-	name        string
-	annotations map[string]string
-	topology    string
-	scenario    string
-	vlanMin     int
-	vlanMax     int
-	vlanAliases map[string]int
-	schedules   map[string]string
-	baseDir     string
+	name         string
+	annotations  map[string]string
+	topology     string
+	scenario     string
+	disabledApps []string
+	vlanMin      int
+	vlanMax      int
+	vlanAliases  map[string]int
+	schedules    map[string]string
+	baseDir      string
 }
 
 func newCreateOptions(opts ...CreateOption) createOptions {
@@ -54,6 +55,12 @@ func CreateWithTopology(t string) CreateOption {
 func CreateWithScenario(s string) CreateOption {
 	return func(o *createOptions) {
 		o.scenario = s
+	}
+}
+
+func CreatedWithDisabledApplications(a []string) CreateOption {
+	return func(o *createOptions) {
+		o.disabledApps = a
 	}
 }
 

--- a/src/go/app/app.go
+++ b/src/go/app/app.go
@@ -244,6 +244,11 @@ func ApplyApps(ctx context.Context, exp *types.Experiment, opts ...Option) error
 				continue
 			}
 
+			// Skip app if disabled, unless stage is ACTIONRUNNING
+			if app.Disabled() && options.Stage != ACTIONRUNNING {
+				continue
+			}
+
 			a := GetApp(app.Name())
 			a.Init(Name(app.Name()), DryRun(options.DryRun))
 

--- a/src/go/cmd/experiment.go
+++ b/src/go/cmd/experiment.go
@@ -114,7 +114,8 @@ func newExperimentCreateCmd() *cobra.Command {
 	example := `
   phenix experiment create <experiment name> -t <topology name or /path/to/filename>
   phenix experiment create <experiment name> -t <topology name or /path/to/filename> -s <scenario name or /path/to/filename>
-  phenix experiment create <experiment name> -t <topology name or /path/to/filename> -s <scenario name or /path/to/filename> -d </path/to/dir/>`
+  phenix experiment create <experiment name> -t <topology name or /path/to/filename> -s <scenario name or /path/to/filename> -d </path/to/dir/>
+  phenix experiment create <experiment name> -t <topology name or /path/to/filename> -s <scenario naem or /path/to/filename> --disabled-apps "app1,app2"`
 
 	cmd := &cobra.Command{
 		Use:     "create <experiment name>",
@@ -157,6 +158,15 @@ func newExperimentCreateCmd() *cobra.Command {
 				scenario = c.Metadata.Name
 			}
 
+			disabledApps, err := cmd.Flags().GetStringSlice("disabled-apps")
+			if err != nil {
+				err := util.HumanizeError(err, "Bad list of disabled-apps provided: %v", disabledApps)
+				return err.Humanized()
+			}
+			for idx := range disabledApps {
+				disabledApps[idx] = strings.TrimSpace(disabledApps[idx])
+			}
+
 			opts := []experiment.CreateOption{
 				experiment.CreateWithName(args[0]),
 				experiment.CreateWithTopology(topology),
@@ -164,6 +174,7 @@ func newExperimentCreateCmd() *cobra.Command {
 				experiment.CreateWithBaseDirectory(MustGetString(cmd.Flags(), "base-dir")),
 				experiment.CreateWithVLANMin(MustGetInt(cmd.Flags(), "vlan-min")),
 				experiment.CreateWithVLANMax(MustGetInt(cmd.Flags(), "vlan-max")),
+				experiment.CreatedWithDisabledApplications(disabledApps),
 			}
 
 			ctx := notes.Context(context.Background(), false)
@@ -187,7 +198,7 @@ func newExperimentCreateCmd() *cobra.Command {
 	cmd.Flags().StringP("base-dir", "d", "", "Base directory to use for experiment (optional)")
 	cmd.Flags().Int("vlan-min", 0, "VLAN pool minimum")
 	cmd.Flags().Int("vlan-max", 0, "VLAN pool maximum")
-
+	cmd.Flags().StringSlice("disabled-apps", []string{}, "Comma separated ist of apps to disable")
 	return cmd
 }
 

--- a/src/go/types/interfaces/scenario.go
+++ b/src/go/types/interfaces/scenario.go
@@ -12,11 +12,13 @@ type ScenarioApp interface {
 	Metadata() map[string]any
 	Hosts() []ScenarioAppHost
 	RunPeriodically() string
+	Disabled() bool
 
 	SetAssetDir(string)
 	SetMetadata(map[string]any)
 	SetHosts([]ScenarioAppHost)
 	SetRunPeriodically(string)
+	SetDisabled(bool)
 
 	ParseMetadata(any) error
 	ParseHostMetadata(string, any) error

--- a/src/go/types/scenario.go
+++ b/src/go/types/scenario.go
@@ -11,6 +11,7 @@ import (
 	v2 "phenix/types/version/v2"
 
 	"github.com/mitchellh/mapstructure"
+	"golang.org/x/exp/slices"
 )
 
 func init() {
@@ -62,6 +63,21 @@ func DecodeScenarioFromConfig(c store.Config) (ifaces.ScenarioSpec, error) {
 	spec, ok := iface.(ifaces.ScenarioSpec)
 	if !ok {
 		return nil, fmt.Errorf("invalid spec in config")
+	}
+
+	return spec, nil
+}
+
+func MakeCustomScenarioFromConfig(c store.Config, disabledApps []string) (ifaces.ScenarioSpec, error) {
+	//Get base spec from config, going to use this to create a custom config
+	spec, err := DecodeScenarioFromConfig(c)
+	if err != nil {
+		return nil, fmt.Errorf("Error make custom scenario: %w", err)
+	}
+
+	//if app name in disabled app list, set to disabled
+	for _, app := range spec.Apps() {
+		app.SetDisabled(slices.Contains(disabledApps, app.Name()))
 	}
 
 	return spec, nil

--- a/src/go/types/version/v2/scenario.go
+++ b/src/go/types/version/v2/scenario.go
@@ -46,6 +46,7 @@ type ScenarioApp struct {
 	MetadataF        map[string]any     `json:"metadata,omitempty" yaml:"metadata,omitempty" structs:"metadata" mapstructure:"metadata"`
 	HostsF           []*ScenarioAppHost `json:"hosts,omitempty" yaml:"hosts,omitempty" structs:"hosts" mapstructure:"hosts"`
 	RunPeriodicallyF string             `json:"runPeriodically,omitempty" yaml:"runPeriodically,omitempty" structs:"runPeriodically" mapstructure:"runPeriodically"`
+	DisabledF        bool               `json:"disabled,omitempty" yaml:"disabled,omitempty" structs:"disabled" mapstructure:"disabled"`
 }
 
 func (this ScenarioApp) Name() string {
@@ -78,6 +79,10 @@ func (this ScenarioApp) RunPeriodically() string {
 	return this.RunPeriodicallyF
 }
 
+func (this ScenarioApp) Disabled() bool {
+	return this.DisabledF
+}
+
 func (this *ScenarioApp) SetAssetDir(dir string) {
 	this.AssetDirF = dir
 }
@@ -98,6 +103,10 @@ func (this *ScenarioApp) SetHosts(hosts []ifaces.ScenarioAppHost) {
 
 func (this *ScenarioApp) SetRunPeriodically(d string) {
 	this.RunPeriodicallyF = d
+}
+
+func (this *ScenarioApp) SetDisabled(d bool) {
+	this.DisabledF = d
 }
 
 func (this ScenarioApp) ParseMetadata(md any) error {

--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -177,6 +177,7 @@ func CreateExperiment(w http.ResponseWriter, r *http.Request) {
 		experiment.CreateWithScenario(req.Scenario),
 		experiment.CreateWithVLANMin(int(req.VlanMin)),
 		experiment.CreateWithVLANMax(int(req.VlanMax)),
+		experiment.CreatedWithDisabledApplications(req.DisabledApps),
 	}
 
 	if req.WorkflowBranch != "" {

--- a/src/go/web/proto/experiment.proto
+++ b/src/go/web/proto/experiment.proto
@@ -69,6 +69,7 @@ message CreateExperimentRequest {
 	uint32 vlan_min = 4 [json_name="vlan_min"];
 	uint32 vlan_max = 5 [json_name="vlan_max"];
 	string workflow_branch = 6 [json_name="workflow_branch"];
+	repeated string disabled_apps = 7 [json_name="disabled_apps"];
 }
 
 message SnapshotRequest {

--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -35,8 +35,10 @@
           <b-taglist>
             <b-tag v-for="( a, index ) in createModal.scenarios[ createModal.scenario ]" 
                   :key="index" 
-                  type="is-light">
-              {{ a }}  
+                  type="is-light"
+                  :class="{'is-success': !a.disabled}"
+                  @click="clickScenario(index)">
+              {{ a.name }}
             </b-tag>
           </b-taglist>
           <b-collapse class="card" animation="slide" :open="false">
@@ -567,6 +569,11 @@
       },
       
       create () {      
+        var disabledApps = this.createModal.scenarios[this.createModal.scenario].filter(
+          (item) => item.disabled
+        ).map(
+            (item) => item.name)
+
         const experimentData = {
           name: this.createModal.name,
           topology: this.createModal.topology,
@@ -574,6 +581,7 @@
           vlan_min: +this.createModal.vlan_min,
           vlan_max: +this.createModal.vlan_max,
           workflow_branch: this.createModal.branch,
+          disabled_apps: disabledApps
         }
         
         if ( !this.createModal.name ) {
@@ -624,7 +632,16 @@
           response => {
             response.json().then( state => {
               if ( state.scenarios != null && Object.keys( state.scenarios ).length != 0 ) {
-                this.createModal.scenarios = state.scenarios;
+                let scenarioObj = {}
+                for (const [name, apps] of Object.entries(state.scenarios)) {
+                  let appList = []
+                  for (var appIdx = 0; appIdx < apps.length; appIdx ++){
+                    appList.push({"name": apps[appIdx], "disabled": false})
+                  }
+                  scenarioObj[name] = appList
+                }
+
+                this.createModal.scenarios = scenarioObj;
                 this.createModal.showScenarios = true;
               }
             });
@@ -632,6 +649,10 @@
             this.errorNotification(err);
           }
         );
+      },
+      clickScenario (id) {
+        let listOfApps = this.createModal.scenarios[this.createModal.scenario]
+        listOfApps[id].disabled = !listOfApps[id].disabled
       },
 
       resetCreateModal () {


### PR DESCRIPTION
This PR allows a user to disable applications from a scenario when creating an experiment. Instead of having to create a separate scenario file and go through the process of setting up phenix again, the user can live-make a custom scenario that is a subset of an existing scenario. The tags that appear when a user selects a scenario on the 'create an new experiment' window can be toggled to disable / enable apps. 

Changes:
- js
  - Make application tags colored + toggle on / off
  - Send list of enabled apps to back end when creating experiment
- go
  - Experiment options has list of enabled apps 
  - When creating experiment, loop over all 'enabled' applications and add from base scenario applications

TODO:
- change color scheme for enabled / disabled tags. The disabled color is the current "normal" color, this may lead to confusion. 
- (future): add apps to a scenario. Live build a custom scenario based on available apps for the topology. Not necessary right now

There would be an issue if two different applications in a scenario shared the same name. Not sure if that is possible. 