### PR TITLE
feat: Add a startup script delay to annotated domain controllers

### DIFF
--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -1,3 +1,18 @@
+{{ $dc := index .Node.Annotations "phenix/domain-controller" }}
+
+{{ if toBool $dc }}
+while ($true) {
+    try {
+        Get-ADDomain | Out-Null
+        Write-Host "[+] Domain Controller services ready!"
+        break
+    } catch {
+        Write-Host "[-] Waiting for Domain Controller services to be ready..."
+        Start-Sleep -Seconds 20
+    }
+}
+{{ end }}
+
 function Phenix-SetStartupStatus($status) {
     echo "Marking phenix startup as $status in registry..."
 


### PR DESCRIPTION
Adds a wait loop in the windows startup script if this annotation is added:

```yaml
      annotations:
        phenix/domain-controller: "true"
```

The wait loop specifically waits for the `Get-ADDomain` command to return, meaning the machine has fully booted and active directory services have started. Without this delay, the DC machine may enter a reboot loop.