### PR TITLE
GetVMInfo:Disk info for VMs on remote nodes

### DIFF
--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -213,6 +213,10 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 			cmd = mmcli.NewCommand()
 			cmd.Command = "disk info " + disk
 
+			if !IsHeadnode(row["host"]) {
+				cmd.Command = fmt.Sprintf("mesh send %s %s", row["host"], cmd.Command)
+			}
+
 			// Only expect one row returned
 			// TODO (btr): check length to avoid a panic.
 			resp := mmcli.RunTabular(cmd)[0]


### PR DESCRIPTION
This fixes a Phenix VM list web page loading error that occurs when a disk image only exists on a remote node.  This is the case when doing a VM snapshot for a VM that exists on a remote node. The minimega `disk info` command which wraps `qemu-img` info is ran on the local node and does not appear to account for disk images on remote nodes.

