### PR TITLE
[UI Feature] Change optical disc from VM modal

### DIFF
--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -109,6 +109,7 @@ func List(expName string) ([]mm.VM, error) {
 			vm.Taps = details.Taps
 			vm.IPv4 = details.IPv4
 			vm.Captures = details.Captures
+			vm.CdRom = details.CdRom
 			vm.Tags = details.Tags
 			vm.Uptime = details.Uptime
 			vm.CPUs = details.CPUs
@@ -229,6 +230,7 @@ func Get(expName, vmName string) (*mm.VM, error) {
 	vm.Taps = details[0].Taps
 	vm.IPv4 = details[0].IPv4
 	vm.Captures = details[0].Captures
+	vm.CdRom = details[0].CdRom
 	vm.Tags = details[0].Tags
 	vm.Uptime = details[0].Uptime
 	vm.CPUs = details[0].CPUs
@@ -1459,3 +1461,55 @@ func StopCaptureSubnet(expName, subnet string, vmList []string) ([]string, error
 	return matchedVMs, nil
 
 }
+
+// Changes the optical disc in the first drive
+func ChangeOpticalDisc(expName, vmName, isoPath string) error {
+
+	if expName == "" {
+		return fmt.Errorf("no experiment name provided")
+	}
+
+	if vmName == "" {
+		return fmt.Errorf("no VM name provided")
+	}
+
+	if isoPath == "" {
+		return fmt.Errorf("no optical disc path provided")
+	}
+
+	
+	cmd := mmcli.NewNamespacedCommand(expName)	
+	cmd.Command = fmt.Sprintf("vm cdrom change %s %s",vmName,isoPath)
+
+	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
+		return fmt.Errorf("changing optical disc for VM %s: %w", vmName, err)
+	}
+	
+
+	
+	return nil
+}
+
+// Ejects the optical disc in the first drive
+func EjectOpticalDisc(expName, vmName string) error {
+
+	if expName == "" {
+		return fmt.Errorf("no experiment name provided")
+	}
+
+	if vmName == "" {
+		return fmt.Errorf("no VM name provided")
+	}
+
+		
+	cmd := mmcli.NewNamespacedCommand(expName)	
+	cmd.Command = fmt.Sprintf("vm cdrom eject %s",vmName)
+
+	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
+		return fmt.Errorf("ejecting optical disc for VM %s: %w", vmName, err)
+	}
+
+	
+	return nil
+}
+

--- a/src/go/util/file.go
+++ b/src/go/util/file.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	filePathRe       = regexp.MustCompile(`filepath=([^ ]+)`)
-	mmFilesDirectory = getMMFilesDirectory()
+	mmFilesDirectory = GetMMFilesDirectory()
 )
 
 // Returns the full path relative to the minimega files directory
@@ -29,7 +29,7 @@ func GetMMFullPath(path string) string {
 }
 
 // Tries to extract the minimega files directory from a process listing
-func getMMFilesDirectory() string {
+func GetMMFilesDirectory() string {
 	defaultMMFilesDirectory := fmt.Sprintf("%s/images", common.PhenixBase)
 
 	cmd := "ps"

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -139,7 +139,7 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 
 	cmd := mmcli.NewNamespacedCommand(o.ns)
 	cmd.Command = "vm info"
-	cmd.Columns = []string{"uuid", "host", "name", "state", "uptime", "vlan", "tap", "ip", "memory", "vcpus", "disks", "snapshot", "tags"}
+	cmd.Columns = []string{"uuid", "host", "name", "state", "uptime", "vlan", "tap", "ip", "memory", "vcpus", "disks", "snapshot", "cdrom", "tags"}
 
 	if o.vm != "" {
 		cmd.Filters = []string{"name=" + o.vm}
@@ -155,6 +155,7 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 			State:    row["state"],
 			Running:  row["state"] == "RUNNING",
 			CCActive: activeC2[row["uuid"]],
+			CdRom: row["cdrom"],
 		}
 
 		s := row["vlan"]

--- a/src/go/util/mm/types.go
+++ b/src/go/util/mm/types.go
@@ -217,6 +217,7 @@ type VM struct {
 	CCActive   bool      `json:"ccActive"`
 	Uptime     float64   `json:"uptime"`
 	Screenshot string    `json:"screenshot,omitempty"`
+	CdRom      string    `json:"cdRom"`
 	Tags       []string  `json:"tags"`
 
 	// Used internally to track network <--> IP relationship, since

--- a/src/go/web/proto/vm.proto
+++ b/src/go/web/proto/vm.proto
@@ -19,11 +19,12 @@ message VM {
   bool busy = 14;
   string experiment = 15;
   string state = 16;
-  repeated string tags = 17;
-  bool cc_active = 18;
-  bool external = 19;
+  string cd_rom = 17;
+  repeated string tags = 18;
+  bool cc_active = 19;
+  bool external = 20;
 
-  string delayed_start = 20 [json_name="delayed_start"];
+  string delayed_start = 21 [json_name="delayed_start"];
 }
 
 message VMList {

--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -190,6 +190,8 @@ func Start(opts ...ServerOption) error {
 	api.HandleFunc("/experiments/{exp}/vms/{name}/stop", StopVM).Methods("POST", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms/{name}/shutdown", ShutdownVM).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms/{name}/redeploy", RedeployVM).Methods("POST", "OPTIONS")
+	api.HandleFunc("/experiments/{exp}/vms/{name}/cdrom", ChangeOpticalDisc).Methods("POST", "OPTIONS")
+	api.HandleFunc("/experiments/{exp}/vms/{name}/cdrom", EjectOpticalDisc).Methods("DELETE", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms/{name}/screenshot.png", GetScreenshot).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms/{name}/vnc", GetVNC).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms/{name}/vnc/ws", GetVNCWebSocket).Methods("GET", "OPTIONS")

--- a/src/go/web/util/protobuf.go
+++ b/src/go/web/util/protobuf.go
@@ -105,6 +105,7 @@ func VMToProtobuf(exp string, vm mm.VM, topology ifaces.TopologySpec) *proto.VM 
 		Busy:       vm.Busy,
 		Experiment: exp,
 		State:      vm.State,
+		CdRom:      vm.CdRom,
 		Tags:       vm.Tags,
 		CcActive:   vm.CCActive,
 	}
@@ -152,11 +153,11 @@ func ExperimentScheduleToProtobuf(exp types.Experiment) *proto.ExperimentSchedul
 func UserToProtobuf(u rbac.User) *proto.User {
 	role, _ := u.Role()
 	user := &proto.User{
-		Username:  u.Username(),
-		FirstName: u.FirstName(),
-		LastName:  u.LastName(),
+		Username:      u.Username(),
+		FirstName:     u.FirstName(),
+		LastName:      u.LastName(),
 		ResourceNames: resourceNamesForRole(role),
-		Role:  RoleToProtobuf(role),
+		Role:          RoleToProtobuf(role),
 	}
 
 	return user
@@ -188,7 +189,7 @@ func resourceNamesForRole(r rbac.Role) []string {
 		rnames = append(rnames, n)
 	}
 	sort.Strings(rnames)
-	
+
 	return rnames
 }
 
@@ -196,14 +197,14 @@ func RoleToProtobuf(r rbac.Role) *proto.Role {
 	policies := make([]*proto.Policy, len(r.Spec.Policies))
 	for i, p := range r.Spec.Policies {
 		policies[i] = &proto.Policy{
-			Resources: p.Resources,
+			Resources:     p.Resources,
 			ResourceNames: p.ResourceNames,
-			Verbs: p.Verbs,
+			Verbs:         p.Verbs,
 		}
 	}
 
 	role := &proto.Role{
-		Name:  r.Spec.Name,
+		Name:     r.Spec.Name,
 		Policies: policies,
 	}
 


### PR DESCRIPTION
Removed the unused `record screenshots` button from the experiment modal in the RunningExperiments view and replaced it with an `insert optical disc` function.  While inserting a disc in the drive of a running VM is fairly straightforward using the minimega command line, being able to insert a disc from the UI is a bit easier and convenient.

The screenshots below show the placement of the `insert optical disc` function/button.  

**Insert Optical Disc button replaces `record screenshots` button**

![expModal_change_iso](https://github.com/sandialabs/sceptre-phenix/assets/75450207/340c6281-dfd1-4c2a-af90-3ced2110bd02)

**Only ISOs appear in the dropdown**

![expModal_change_iso_dropdown](https://github.com/sandialabs/sceptre-phenix/assets/75450207/3991a3a9-13fc-4a71-9ccb-25d485143c2c)



