### PR TITLE
Changes to Docker build to improve dev workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
             MM_MIN_REV=2b2b341
             PHENIX_COMMIT=${{ env.sha }}
             PHENIX_TAG=${{ env.branch }}
-            APPS_REPO=${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}
+            APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/phenix:${{ env.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 bin
 
 staticcheck.conf
+
+.venv

--- a/README.md
+++ b/README.md
@@ -4,22 +4,25 @@ Welcome to `phenix`!
 
 ## Building
 
-To build locally, you will need Golang v1.18, Node v14.2, Yarn 1.22, and Protoc
-3.14 installed. Once installed (if not already), simply run `make bin/phenix`.
+### Local build
+To build locally, you will need Golang v1.18, Node v14.2, Yarn 1.22, and Protoc 3.14 installed.
 
-If you don't want to install Golang and/or Node locally, you can also use Docker
-to build phenix (assuming you have Docker installed). Simply run
-`./docker-build.sh` and once built, the phenix binary will be available at
-`bin/phenix`. See `./docker-build.sh -h` for usage details.
-
-A Docker image is also hosted in this repo under Packages and can be pulled via:
-
+Once installed (if not already), simply run:
+```bash
+make bin/phenix
 ```
-$> docker pull ghcr.io/sandialabs/sceptre-phenix/phenix:main
-```
+
+If you don't want to install Golang and/or Node locally, you can also use Docker to build phenix (assuming you have Docker installed). Simply run `./hack/build/docker-build.sh` and once built, the phenix binary will be available at `bin/phenix`. Run `./hack/build/docker-build.sh -h` for usage details.
+
+### Docker build
+Docker is the recommended way to build and deploy phenix.
 
 The Docker image is updated automatically each time a commit is pushed to the
-`main` branch.
+`main` branch. To pull the latest image:
+
+```shell
+docker pull ghcr.io/sandialabs/sceptre-phenix/phenix:main
+```
 
 > **NOTE**: currently the `main` image available on GHCR defaults to
 > having UI authentication disabled. If you want to enable authentication,
@@ -51,7 +54,7 @@ These tags are stored as a string `key1=value1,key2=value2`.
 
 ### Add/Update Topology or Scenario Config
 
-```
+```bash
 curl -XPOST -H "Content-Type: application/x-yaml" \
   --data-binary @{/path/to/config/file.yml} \
   http://localhost:3000/api/v1/workflow/configs/{branch name}
@@ -59,7 +62,7 @@ curl -XPOST -H "Content-Type: application/x-yaml" \
 
 ### Apply phenix Workflow Config
 
-```
+```bash
 curl -XPOST -H "Content-Type: application/x-yaml" \
   --data-binary @{/path/to/config/file.yml} \
   http://localhost:3000/api/v1/workflow/apply/{branch name}[?tag=key1=value1&tag=key2=value2]
@@ -69,7 +72,7 @@ curl -XPOST -H "Content-Type: application/x-yaml" \
 
 Below is an example phenix workflow config file.
 
-```
+```yaml
 apiVersion: phenix.sandia.gov/v0
 kind: Workflow
 metadata: {}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ ARG  MM_MIN_REV=2bd71c0
 FROM ghcr.io/activeshadow/minimega/minimega:${MM_MIN_REV} AS minimega
 
 
+# ** jsbuilder **
 FROM node:14.21.3 AS jsbuilder
 
 ARG INSTALL_CERTS=
@@ -38,6 +39,7 @@ WORKDIR /phenix/src/go/web/public/docs
 RUN npx redoc-cli build openapi.yml -o index.html --title 'phenix API'
 
 
+# ** gobuilder **
 FROM golang:1.20.7 AS gobuilder
 
 RUN apt update \
@@ -49,6 +51,7 @@ COPY ./src/go   /phenix/src/go
 
 WORKDIR /phenix
 
+# Copy files from jsbuilder stage
 COPY --from=jsbuilder /phenix/src/js /phenix/src/js
 COPY --from=jsbuilder /phenix/src/go/web/public/docs/index.html /phenix/src/go/web/public/docs/index.html
 
@@ -67,19 +70,35 @@ ARG PHENIX_TAG
 RUN COMMIT=${PHENIX_COMMIT} TAG=${PHENIX_TAG} make bin/phenix
 RUN make -C src/go phenix-tunneler
 
-ARG APPS_REPO=sandialabs/sceptre-phenix-apps
+# Allow installing from a fork of sceptre-phenix-apps that could
+# exist on GitHub or elsewhere.
+ARG APPS_REPO=github.com/sandialabs/sceptre-phenix-apps
 ARG APPS_BRANCH=main
 
-RUN git clone --branch ${APPS_BRANCH} https://github.com/${APPS_REPO}.git /phenix-apps
+RUN git clone --branch ${APPS_BRANCH} https://${APPS_REPO}.git /phenix-apps
 
 WORKDIR /phenix-apps/src/go
 
 RUN CGO_ENABLED=0 GOOS=linux go install -trimpath ./...
 
 
+# ** Build the phenix image **
 FROM ubuntu:22.04
 
-ENV TZ=Etc/UTC
+# General image metadata
+# Reference: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+ARG PHENIX_COMMIT
+LABEL org.opencontainers.image.authors="Sandia National Laboratories <emulytics@sandia.gov>, Bryan Richardson <bryan@activeshadow.com>" \
+  org.opencontainers.image.documentation="https://phenix.sceptre.dev/" \
+  org.opencontainers.image.source="https://github.com/sandialabs/sceptre-phenix" \
+  org.opencontainers.image.revision="${PHENIX_COMMIT}" \
+  org.opencontainers.image.vendor="Sandia National Laboratories" \
+  org.opencontainers.image.licenses="GPL-3.0-or-later" \
+  org.opencontainers.image.title="phenix" \
+  org.opencontainers.image.description="phenix is an orchestration tool and GUI for Sandia's minimega platform"
+
+# Set timezone
+ENV TZ="Etc/UTC"
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # tshark needed for scorch tcpdump component
@@ -92,8 +111,9 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /var/cache/apt/archives/*
 
-ENV LANG   en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+ENV LANG="en_US.UTF-8" \
+  LC_ALL="en_US.UTF-8" \
+  PIP_DISABLE_PIP_VERSION_CHECK=1
 
 ARG INSTALL_CERTS=
 RUN ["/bin/bash", "-c", "if [ -n $INSTALL_CERTS ]; then \
@@ -108,30 +128,41 @@ RUN ["/bin/bash", "-c", "if [ -n $INSTALL_CERTS ]; then \
 RUN wget https://github.com/glattercj/vmdb2/releases/download/v1.1/vmdb2 -O /usr/bin/vmdb2 \
   && chmod +x /usr/bin/vmdb2
 
-# do this before installing phenix-apps so minimega package is latest version
-COPY --from=minimega /opt/minimega/lib /tmp/minimega
-RUN  python3 -m pip install /tmp/minimega
-
-ARG APPS_REPO=sandialabs/sceptre-phenix-apps
-ARG APPS_BRANCH=main
-
-RUN python3 -m pip install \
-  --trusted-host pypi.org \
-  --trusted-host files.pythonhosted.org \
-  "git+https://github.com/${APPS_REPO}.git@${APPS_BRANCH}#egg=phenix-apps&subdirectory=src/python"
-
 # needed to build Kali images with phenix
 RUN wget -O kali.deb https://http.kali.org/kali/pool/main/k/kali-archive-keyring/kali-archive-keyring_2022.1_all.deb \
-	&& dpkg -i kali.deb && rm kali.deb
+  && dpkg -i kali.deb \
+  && rm kali.deb
 
 # used by scorch
 RUN wget -O glow.tgz https://github.com/charmbracelet/glow/releases/download/v1.5.0/glow_1.5.0_Linux_x86_64.tar.gz \
-  && tar -xzf glow.tgz glow && mv glow /usr/local/bin/glow && rm glow.tgz
+  && tar -xzf glow.tgz glow \
+  && mv glow /usr/local/bin/glow \
+  && rm glow.tgz
 
 # used by scorch
 RUN wget -O filebeat.deb https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.17.5-amd64.deb \
-	&& dpkg -i filebeat.deb && rm filebeat.deb
+  && dpkg -i filebeat.deb \
+  && rm filebeat.deb
 
+# Allow the use of PyPI mirrors via build args
+ARG PIP_INDEX="https://pypi.org/"
+ARG PIP_INDEX_URL="https://pypi.org/simple"
+
+# Do this before installing phenix-apps so minimega package is latest version
+COPY --from=minimega /opt/minimega/lib /tmp/minimega
+RUN python3 -m pip install --no-cache-dir /tmp/minimega
+
+# Allow installing from a fork of sceptre-phenix-apps that could
+# exist on GitHub or elsewhere.
+ARG APPS_REPO=github.com/sandialabs/sceptre-phenix-apps
+ARG APPS_BRANCH=main
+
+# Install phenix user apps
+RUN python3 -m pip install \
+  --no-cache-dir \
+  "git+https://${APPS_REPO}.git@${APPS_BRANCH}#egg=phenix-apps&subdirectory=src/python"
+
+# Copy binaries from gobuilder stage
 COPY --from=gobuilder /phenix/bin/phenix   /usr/local/bin/phenix
 COPY --from=gobuilder /go/bin/phenix-app-* /usr/local/bin
 


### PR DESCRIPTION
## Summary

The primary reason for this PR is to allow usage of non-GitHub repos to be used for `APPS_REPO` during the Docker image build. There are also a number of other enhancements to the Dockerfile and a handful of updates to the README (just some cleanup while I was in the area).

## Changes

- APPS_REPO must now include the base domain for the repo. By default, this is github.com. The change should have minimal impact on existing workflows. This change enables use of other Git hosts for phenix-apps.
- Add some labels to the image metadata.
This is a best practice that we use for several other projects.
- Disable pip update checks
- Disable pip caching
- Move scorch dependency installs before python installs, to improve caching (since these usually don't change, so docker buildkit can cache and not have to pull when rebuilding)
- Add ability to configure pip index via build arg.
This enables use of PyPI mirrors to speed up builds and dodge proxy errors.
- Remove --trusted-host arguments from pip. There's no reason to have these if the certificates are installed.
- Add a few comments explaining stages
- Update APPS_REPO in the docker GitHub Action workflow
- Add `.venv` to `.gitignore`
- Minor changes to `README.md`