### PR TITLE
fix(ui): allow experiment to be created without a scenario

### DIFF
--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -568,11 +568,14 @@
         }
       },
       
-      create () {      
-        var disabledApps = this.createModal.scenarios[this.createModal.scenario].filter(
-          (item) => item.disabled
-        ).map(
-            (item) => item.name)
+      create () {
+        var disabledApps = []
+        if (this.createModal.scenario != null){
+          disabledApps = this.createModal.scenarios[this.createModal.scenario].filter(
+            (item) => item.disabled
+          ).map(
+              (item) => item.name)
+        }
 
         const experimentData = {
           name: this.createModal.name,


### PR DESCRIPTION
Adding a null check before creating disabledApps list. Create window works with and without a scenario selected. 

@activeshadow Not sure how to link this pull request with the issue -- this will resolve issue #158 