### PR TITLE
Disable extended clipboard in noVNC

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           build-args: |
-            MM_MIN_REV=2b2b341
+            MM_MIN_REV=48a8fe5
             PHENIX_COMMIT=${{ env.sha }}
             PHENIX_TAG=${{ env.branch }}
             APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}

--- a/.github/workflows/minimega.yml
+++ b/.github/workflows/minimega.yml
@@ -28,10 +28,10 @@ jobs:
           context: docker
           file: docker/Dockerfile.minimega
           build-args: |
-            MM_REV=2b2b341
+            MM_REV=48a8fe5
             PHENIX_REVISION=${{ env.sha }}
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/minimega:2b2b341
+            ghcr.io/${{ github.repository }}/minimega:48a8fe5
             ghcr.io/${{ github.repository }}/minimega:${{ env.sha }}
             ghcr.io/${{ github.repository }}/minimega:${{ env.branch }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Update GitHub workflow config to change the minimum version of minimega
 # required for use with phenix. This build stage is needed for making sure the
 # latest version of the minimega Python module is installed.
-ARG  MM_MIN_REV=2bd71c0
+ARG  MM_MIN_REV=48a8fe5
 FROM ghcr.io/activeshadow/minimega/minimega:${MM_MIN_REV} AS minimega
 
 
@@ -170,7 +170,7 @@ COPY --from=gobuilder /phenix/src/go/bin/phenix-tunneler-* /opt/phenix/downloads
 
 # Update GitHub workflow config to change the minimum version of minimega
 # required for use with phenix.
-ARG   MM_MIN_REV=2b2b341
+ARG   MM_MIN_REV=48a8fe5
 LABEL gov.sandia.phenix.minimega-min-revision="ghcr.io/sandialabs/sceptre-phenix/minimega:${MM_MIN_REV}"
 
 WORKDIR /opt/phenix

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       args:
-        MM_MIN_REV: 2b2b341
+        MM_MIN_REV: 48a8fe5
         PHENIX_WEB_AUTH: disabled
     command:
     - phenix
@@ -44,7 +44,7 @@ services:
       context: .
       dockerfile: Dockerfile.minimega
       args:
-        MM_REV: 2b2b341
+        MM_REV: 48a8fe5
     image: minimega
     container_name: minimega
     privileged: true

--- a/src/go/web/public/novnc/core/rfb.js
+++ b/src/go/web/public/novnc/core/rfb.js
@@ -1885,7 +1885,8 @@ export default class RFB extends EventTargetMixin {
 
                     // Check if format flag is set.
                     if ((formats & index)) {
-                        this._clipboardServerCapabilitiesFormats[index] = true;
+                        // PHENIX EDIT: minimega vnc shim doesn't support extended clipboard, so don't store formats
+                        // this._clipboardServerCapabilitiesFormats[index] = true;
                         // We don't send unsolicited clipboard, so we
                         // ignore the size
                         this._sock.rQshift32();

--- a/src/go/web/public/vnc.html
+++ b/src/go/web/public/vnc.html
@@ -6,8 +6,11 @@
     3. Preventing the `_qemuExtKeyEventSupported` flag from getting set to true in `core/rfb.js`
        This flag is used to upgrade key event messages to a new format, but vnc recording/playback
        does not support the newer format
-    4. Add the banner and styling to this file
-    5. Remove title changing in `app/ui.js` since we set it with templating
+    4. Preventing the `_clipboardServerCapabilitiesFormats` flags from getting set in `core/rfb.js`.
+       These flags represent support for the extended clipboard pseudo-encoding which minimega does
+       not support
+    5. Add the banner and styling to this file
+    6. Remove title changing in `app/ui.js` since we set it with templating
 -->
 <!DOCTYPE html>
 <html lang="en" class="noVNC_loading">


### PR DESCRIPTION
This is a minor update that coincides with a minimega PR adding copy/paste support: https://github.com/sandia-minimega/minimega/pull/1520

This disables noVNC from using the [extended clipboard pseudo encoding](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#extended-clipboard-pseudo-encoding). Minimega uses a passive shim to read RFB messages, and can't support the extended clipboard.