### PR TITLE
fix: provide options for VM CPU cores, threads, and sockets

### DIFF
--- a/src/go/tmpl/templates/minimega_script.tmpl
+++ b/src/go/tmpl/templates/minimega_script.tmpl
@@ -42,6 +42,9 @@ clear vm config
 vm config schedule {{ index $.Schedules .General.Hostname }}
         {{- end }}
 vm config vcpus {{ .Hardware.VCPU }}
+vm config cores {{ .Hardware.Core }}
+vm config threads {{ .Hardware.Thread }}
+vm config sockets {{ .Hardware.Socket }}
 vm config cpu {{ .Hardware.CPU }}
 vm config memory {{ .Hardware.Memory }}
 vm config snapshot {{ derefBool .General.Snapshot }}

--- a/src/go/types/interfaces/topology.go
+++ b/src/go/types/interfaces/topology.go
@@ -63,11 +63,17 @@ type NodeGeneral interface {
 type NodeHardware interface {
 	CPU() string
 	VCPU() int
+	Core() int
+	Thread() int
+	Socket() int
 	Memory() int
 	OSType() string
 	Drives() []NodeDrive
 
 	SetVCPU(int)
+	SetCore(int)
+	SetThread(int)
+	SetSocket(int)
 	SetMemory(int)
 
 	AddDrive(string, int) NodeDrive

--- a/src/go/types/version/v0/node.go
+++ b/src/go/types/version/v0/node.go
@@ -197,6 +197,9 @@ func (this *General) SetDoNotBoot(b bool) {
 type Hardware struct {
 	CPUF    string   `json:"cpu" yaml:"cpu" structs:"cpu" mapstructure:"cpu"`
 	VCPUF   int      `json:"vcpus,string" yaml:"vcpus" structs:"vcpus" mapstructure:"vcpus"`
+	CoreF   int      `json:"cores" yaml:"cores" structs:"cores" mapstructure:"cores"`
+	ThreadF int      `json:"threads" yaml:"threads" structs:"threads" mapstructure:"threads"`
+	SocketF int      `json:"sockets" yaml:"sockets" structs:"sockets" mapstructure:"sockets"`
 	MemoryF int      `json:"memory,string" yaml:"memory" structs:"memory" mapstructure:"memory"`
 	OSTypeF string   `json:"os_type" yaml:"os_type" structs:"os_type" mapstructure:"os_type"`
 	DrivesF []*Drive `json:"drives" yaml:"drives" structs:"drives" mapstructure:"drives"`
@@ -208,6 +211,18 @@ func (this Hardware) CPU() string {
 
 func (this Hardware) VCPU() int {
 	return this.VCPUF
+}
+
+func (this Hardware) Core() int {
+	return this.CoreF
+}
+
+func (this Hardware) Thread() int {
+	return this.ThreadF
+}
+
+func (this Hardware) Socket() int {
+	return this.SocketF
 }
 
 func (this Hardware) Memory() int {
@@ -230,6 +245,18 @@ func (this Hardware) Drives() []ifaces.NodeDrive {
 
 func (this *Hardware) SetVCPU(v int) {
 	this.VCPUF = v
+}
+
+func (this *Hardware) SetCore(c int) {
+	this.CoreF = c
+}
+
+func (this *Hardware) SetThread(t int) {
+	this.ThreadF = t
+}
+
+func (this *Hardware) SetSocket(s int) {
+	this.SocketF = s
 }
 
 func (this *Hardware) SetMemory(m int) {

--- a/src/go/types/version/v1/node.go
+++ b/src/go/types/version/v1/node.go
@@ -316,6 +316,9 @@ func (this *General) SetDoNotBoot(b bool) {
 type Hardware struct {
 	CPUF    string   `json:"cpu" yaml:"cpu" structs:"cpu" mapstructure:"cpu"`
 	VCPUF   int      `json:"vcpus" yaml:"vcpus" structs:"vcpus" mapstructure:"vcpus"`
+	CoreF   int      `json:"cores" yaml:"cores" structs:"cores" mapstructure:"cores"`
+	ThreadF int      `json:"threads" yaml:"threads" structs:"threads" mapstructure:"threads"`
+	SocketF int      `json:"sockets" yaml:"sockets" structs:"sockets" mapstructure:"sockets"`
 	MemoryF int      `json:"memory" yaml:"memory" structs:"memory" mapstructure:"memory"`
 	OSTypeF string   `json:"os_type" yaml:"os_type" structs:"os_type" mapstructure:"os_type"`
 	DrivesF []*Drive `json:"drives" yaml:"drives" structs:"drives" mapstructure:"drives"`
@@ -335,6 +338,34 @@ func (this *Hardware) VCPU() int {
 	}
 
 	return this.VCPUF
+}
+
+func (this *Hardware) Core() int {
+	if this == nil {
+		return 0
+	}
+
+	return this.CoreF
+}
+
+func (this *Hardware) Thread() int {
+	if this == nil {
+		return 0
+	}
+
+	return this.ThreadF
+}
+
+func (this *Hardware) Socket() int {
+	if this == nil {
+		return 0
+	}
+
+	if this.SocketF == 0 {
+		return 1
+	}
+
+	return this.SocketF
 }
 
 func (this *Hardware) Memory() int {
@@ -369,6 +400,18 @@ func (this *Hardware) Drives() []ifaces.NodeDrive {
 
 func (this *Hardware) SetVCPU(v int) {
 	this.VCPUF = v
+}
+
+func (this *Hardware) SetCore(c int) {
+	this.CoreF = c
+}
+
+func (this *Hardware) SetThread(t int) {
+	this.ThreadF = t
+}
+
+func (this *Hardware) SetSocket(s int) {
+	this.SocketF = s
 }
 
 func (this *Hardware) SetMemory(m int) {


### PR DESCRIPTION
Within the hardware section of the node configuration, at the same level as `vcpus`, you can now also provide `cores`, `threads`, and `sockets` settings.

fixes #167