### PR TITLE
feat: add disk space to hosts tab in phenix ui

### DIFF
--- a/src/go/util/mm/types.go
+++ b/src/go/util/mm/types.go
@@ -122,21 +122,27 @@ type Cluster struct {
 }
 
 type Host struct {
-	Name        string   `json:"name"`
-	CPUs        int      `json:"cpus"`
-	CPUCommit   int      `json:"cpucommit"`
-	Load        []string `json:"load"`
-	MemUsed     int      `json:"memused"`
-	MemTotal    int      `json:"memtotal"`
-	MemCommit   int      `json:"memcommit"`
-	Tx          float64  `json:"tx"`
-	Rx          float64  `json:"rx"`
-	Bandwidth   string   `json:"bandwidth"`
-	NetCommit   int      `json:"netcommit"`
-	VMs         int      `json:"vms"`
-	Uptime      float64  `json:"uptime"`
-	Schedulable bool     `json:"schedulable"`
-	Headnode    bool     `json:"headnode"`
+	Name        string    `json:"name"`
+	CPUs        int       `json:"cpus"`
+	CPUCommit   int       `json:"cpucommit"`
+	Load        []string  `json:"load"`
+	MemUsed     int       `json:"memused"`
+	MemTotal    int       `json:"memtotal"`
+	MemCommit   int       `json:"memcommit"`
+	Tx          float64   `json:"tx"`
+	Rx          float64   `json:"rx"`
+	Bandwidth   string    `json:"bandwidth"`
+	DiskUsage   DiskUsage `json:"diskusage"`
+	NetCommit   int       `json:"netcommit"`
+	VMs         int       `json:"vms"`
+	Uptime      float64   `json:"uptime"`
+	Schedulable bool      `json:"schedulable"`
+	Headnode    bool      `json:"headnode"`
+}
+
+type DiskUsage struct {
+	Phenix   float64 `json:"diskphenix"`
+	Minimega float64 `json:"diskminimega"`
 }
 
 type VMs []VM

--- a/src/js/src/components/Hosts.vue
+++ b/src/js/src/components/Hosts.vue
@@ -44,6 +44,15 @@ available for experiments, the number of VMs, and host uptime.
         <b-table-column field="mem_total" label="RAM Total" width="100" centered v-slot="props">
           {{ props.row.memtotal | ram }}
         </b-table-column>
+        <b-table-column field="disk_used" label="Disk Used (% phenix/minimega base)" width="200" centered v-slot="props">
+          <span class="tag" :class="decorator(props.row.diskusage.diskphenix, 100.0)">
+            {{ props.row.diskusage.diskphenix }}
+          </span>
+          /
+          <span class="tag" :class="decorator(props.row.diskusage.diskminimega, 100.0)">
+            {{ props.row.diskusage.diskminimega }}
+          </span>
+        </b-table-column>
         <b-table-column field="bandwidth" label="Bandwidth (MB/sec)" width="200" centered v-slot="props">
           {{ props.row.bandwidth }}
         </b-table-column>


### PR DESCRIPTION
Add disk space % to Hosts tab in phenix UI - uses `df` on `common.PhenixBase` and `common.MinimegaBase`.

<img width="513" alt="Screenshot 2024-02-08 at 21 46 00" src="https://github.com/sandialabs/sceptre-phenix/assets/8338736/3bf6dcbe-0931-49c1-8dd9-566c795bf891">