### PR TITLE
fix: avoid tunnel failures from expected errors

### DIFF
--- a/src/go/util/mm/mmcli/tabular.go
+++ b/src/go/util/mm/mmcli/tabular.go
@@ -3,7 +3,6 @@
 package mmcli
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/activeshadow/libminimega/minicli"
@@ -65,7 +64,6 @@ func RunTabular(cmd *Command) []map[string]string {
 	for resps := range Run(cmd) {
 		for _, resp := range resps.Resp {
 			if resp.Error != "" {
-				fmt.Println(resp.Error)
 				continue
 			}
 


### PR DESCRIPTION
When `cc tunnel` is run in a namespace that has multiple nodes, each node will try to create the tunnel and only one will succeed since the VM being used for the tunnel will only be on one node. The other nodes will report back an error, and this was causing phēnix to assume the tunnel creation had failed.

This commit updates the `cc tunnel` command to be prefixed with the node to execute the command on rather than having it sprayed to all nodes.