### PR TITLE
User Annotation Improvements

### DIFF
--- a/src/go/api/soh/soh.go
+++ b/src/go/api/soh/soh.go
@@ -17,12 +17,6 @@ func Get(expName, statusFilter string) (*Network, error) {
 	// Create an empty network
 	network := new(Network)
 
-	// Create structure to format nodes' font
-	font := Font{
-		Color: "whitesmoke",
-		Align: "center",
-	}
-
 	exp, err := experiment.Get(expName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get experiment %s: %w", expName, err)
@@ -107,7 +101,7 @@ func Get(expName, statusFilter string) (*Network, error) {
 			ID:     vm.ID,
 			Label:  vm.Name,
 			Image:  vm.OSType,
-			Fonts:  font,
+			Tags:   vm.Tags,
 			Status: vmState,
 		}
 
@@ -140,7 +134,7 @@ func Get(expName, statusFilter string) (*Network, error) {
 					ID:     ifaceCount,
 					Label:  vmIface,
 					Image:  "switch",
-					Fonts:  font,
+					Tags:   vm.Tags,
 					Status: "ignore",
 				}
 

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -5,18 +5,13 @@ import (
 	"time"
 )
 
-type Font struct {
-	Color string `json:"color"`
-	Align string `json:"align"`
-}
-
 type Node struct {
-	ID     int        `json:"id"`
-	Label  string     `json:"label"`
-	Image  string     `json:"image"`
-	Fonts  Font       `json:"font"`
-	Status string     `json:"status"`
-	SOH    *HostState `json:"soh"`
+	ID     int               `json:"id"`
+	Label  string            `json:"label"`
+	Image  string            `json:"image"`
+	Tags   map[string]string `json:"tags"`
+	Status string            `json:"status"`
+	SOH    *HostState        `json:"soh"`
 }
 
 type Edge struct {

--- a/src/go/api/vm/option.go
+++ b/src/go/api/vm/option.go
@@ -8,16 +8,18 @@ type iface struct {
 }
 
 type updateOptions struct {
-	exp       string
-	vm        string
-	cpu       int
-	mem       int
-	disk      string
-	partition int
-	dnb       *bool
-	iface     *iface
-	host      *string
-	snapshot  *bool
+	exp        string
+	vm         string
+	cpu        int
+	mem        int
+	disk       string
+	partition  int
+	dnb        *bool
+	iface      *iface
+	host       *string
+	snapshot   *bool
+	appendTags bool
+	tags       *map[string]string
 }
 
 func newUpdateOptions(opts ...UpdateOption) updateOptions {
@@ -78,15 +80,22 @@ func UpdateWithDNB(b bool) UpdateOption {
 	}
 }
 
+func UpdateWithHost(h string) UpdateOption {
+	return func(o *updateOptions) {
+		o.host = &h
+	}
+}
+
 func UpdateWithSnapshot(b bool) UpdateOption {
 	return func(o *updateOptions) {
 		o.snapshot = &b
 	}
 }
 
-func UpdateWithHost(h string) UpdateOption {
+func UpdateWithTags(t map[string]string, appendTags bool) UpdateOption {
 	return func(o *updateOptions) {
-		o.host = &h
+		o.appendTags = appendTags
+		o.tags = &t
 	}
 }
 

--- a/src/go/tmpl/templates/minimega_script.tmpl
+++ b/src/go/tmpl/templates/minimega_script.tmpl
@@ -63,7 +63,7 @@ vm config {{ $config }} {{ $value }}
 vm config qemu-override "{{ $match }}" "{{ $replacement }}"
         {{- end }}
         {{- range $label, $value := .Labels }}
-vm config tags {{ $label }} {{ $value }}
+vm config tags "{{ $label }}" "{{ escapeNewline $value }}"
         {{- end }}
 vm launch {{ .General.VMType }} {{ .General.Hostname }}
     {{- end }}

--- a/src/go/tmpl/tmpl.go
+++ b/src/go/tmpl/tmpl.go
@@ -60,6 +60,9 @@ func GenerateFromTemplate(name string, data interface{}, w io.Writer) error {
 		"stringsJoin": func(s []string, sep string) string {
 			return strings.Join(s, sep)
 		},
+		"escapeNewline": func(s string) string {
+			return strings.ReplaceAll(s, "\n", "\\n")
+		},
 	}
 
 	tmpl := template.Must(template.New(name).Funcs(funcs).Parse(string(MustAsset(name))))

--- a/src/go/types/interfaces/topology.go
+++ b/src/go/types/interfaces/topology.go
@@ -37,6 +37,7 @@ type NodeSpec interface {
 
 	SetInjections([]NodeInjection)
 	SetType(string)
+	SetLabels(map[string]string)
 
 	AddAnnotation(string, interface{})
 	AddTimerDelay(delay string)

--- a/src/go/types/version/v0/node.go
+++ b/src/go/types/version/v0/node.go
@@ -89,6 +89,10 @@ func (this *Node) SetType(t string) {
 	this.TypeF = t
 }
 
+func (this *Node) SetLabels(m map[string]string) {
+	this.LabelsF = m
+}
+
 func (this *Node) AddAnnotation(k string, i interface{}) {
 	if this.AnnotationsF == nil {
 		this.AnnotationsF = make(map[string]interface{})

--- a/src/go/types/version/v1/node.go
+++ b/src/go/types/version/v1/node.go
@@ -106,6 +106,10 @@ func (this *Node) SetType(t string) {
 	this.TypeF = t
 }
 
+func (this *Node) SetLabels(m map[string]string) {
+	this.LabelsF = m
+}
+
 func (this *Node) AddAnnotation(k string, i interface{}) {
 	if this.AnnotationsF == nil {
 		this.AnnotationsF = make(map[string]interface{})

--- a/src/go/util/mm/mm.go
+++ b/src/go/util/mm/mm.go
@@ -19,6 +19,8 @@ type MM interface {
 	GetVMHost(...Option) (string, error)
 	GetVMState(...Option) (string, error)
 
+	SetVMTags(...Option) error
+
 	ConnectVMInterface(...Option) error
 	DisconnectVMInterface(...Option) error
 

--- a/src/go/util/mm/option.go
+++ b/src/go/util/mm/option.go
@@ -17,6 +17,8 @@ type options struct {
 	disk   string
 	bridge string
 
+	tags map[string]string
+
 	injectPart int
 	injects    []string
 
@@ -77,6 +79,12 @@ func Disk(d string) Option {
 func Bridge(b string) Option {
 	return func(o *options) {
 		o.bridge = b
+	}
+}
+
+func Tags(t map[string]string) Option {
+	return func(o *options) {
+		o.tags = t
 	}
 }
 

--- a/src/go/util/mm/package.go
+++ b/src/go/util/mm/package.go
@@ -52,6 +52,10 @@ func GetVMState(opts ...Option) (string, error) {
 	return DefaultMM.GetVMState(opts...)
 }
 
+func SetVMTags(opts ...Option) error {
+	return DefaultMM.SetVMTags(opts...)
+}
+
 func ConnectVMInterface(opts ...Option) error {
 	return DefaultMM.ConnectVMInterface(opts...)
 }

--- a/src/go/util/mm/types.go
+++ b/src/go/util/mm/types.go
@@ -206,30 +206,30 @@ func (this VMs) Paginate(page, size int) VMs {
 }
 
 type VM struct {
-	ID              int       `json:"id"`
-	Name            string    `json:"name"`
-	Type            string    `json:"type"`
-	Experiment      string    `json:"experiment"`
-	Host            string    `json:"host"`
-	IPv4            []string  `json:"ipv4"`
-	CPUs            int       `json:"cpus"`
-	RAM             int       `json:"ram"`
-	Disk            string    `json:"disk"`
-	InjectPartition int       `json:"inject_partition`
-	OSType          string    `json:"osType"`
-	DoNotBoot       bool      `json:"dnb"`
-	Networks        []string  `json:"networks"`
-	Taps            []string  `json:"taps"`
-	Captures        []Capture `json:"captures"`
-	State           string    `json:"state"`
-	Running         bool      `json:"running"`
-	Busy            bool      `json:"busy"`
-	CCActive        bool      `json:"ccActive"`
-	Uptime          float64   `json:"uptime"`
-	Screenshot      string    `json:"screenshot,omitempty"`
-	CdRom           string    `json:"cdRom"`
-	Tags            []string  `json:"tags"`
-	Snapshot        bool      `json:"snapshot"`
+	ID              int               `json:"id"`
+	Name            string            `json:"name"`
+	Type            string            `json:"type"`
+	Experiment      string            `json:"experiment"`
+	Host            string            `json:"host"`
+	IPv4            []string          `json:"ipv4"`
+	CPUs            int               `json:"cpus"`
+	RAM             int               `json:"ram"`
+	Disk            string            `json:"disk"`
+	InjectPartition int               `json:"inject_partition"`
+	OSType          string            `json:"osType"`
+	DoNotBoot       bool              `json:"dnb"`
+	Networks        []string          `json:"networks"`
+	Taps            []string          `json:"taps"`
+	Captures        []Capture         `json:"captures"`
+	State           string            `json:"state"`
+	Running         bool              `json:"running"`
+	Busy            bool              `json:"busy"`
+	CCActive        bool              `json:"ccActive"`
+	Uptime          float64           `json:"uptime"`
+	Screenshot      string            `json:"screenshot,omitempty"`
+	CdRom           string            `json:"cdRom"`
+	Tags            map[string]string `json:"tags"`
+	Snapshot        bool              `json:"snapshot"`
 
 	// Used internally to track network <--> IP relationship, since
 	// network ordering from minimega may not be the same as network
@@ -263,8 +263,10 @@ func (this VM) Copy() VM {
 	vm.Captures = make([]Capture, len(this.Captures))
 	copy(vm.Captures, this.Captures)
 
-	vm.Tags = make([]string, len(this.Tags))
-	copy(vm.Tags, this.Tags)
+	vm.Tags = make(map[string]string, len(this.Tags))
+	for k, v := range this.Tags {
+		vm.Tags[k] = v
+	}
 
 	return vm
 }

--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -1045,6 +1045,12 @@ func UpdateVM(w http.ResponseWriter, r *http.Request) {
 		opts = append(opts, vm.UpdateWithInterface(int(req.Interface.Index), req.Interface.Vlan))
 	}
 
+	if req.TagUpdateMode == proto.TagUpdateMode_SET {
+		opts = append(opts, vm.UpdateWithTags(req.Tags, false))
+	} else if req.TagUpdateMode == proto.TagUpdateMode_ADD {
+		opts = append(opts, vm.UpdateWithTags(req.Tags, true))
+	}
+
 	switch req.Boot.(type) {
 	case *proto.UpdateVMRequest_DoNotBoot:
 		opts = append(opts, vm.UpdateWithDNB(req.GetDoNotBoot()))

--- a/src/go/web/proto/vm.proto
+++ b/src/go/web/proto/vm.proto
@@ -20,7 +20,7 @@ message VM {
   string experiment = 15;
   string state = 16;
   string cd_rom = 17;
-  repeated string tags = 18;
+  map<string, string> tags = 18;
   bool cc_active = 19;
   bool external = 20;
   string delayed_start = 21 [json_name="delayed_start"];
@@ -55,6 +55,14 @@ message VMRedeployRequest {
   bool injects = 5;
 }
 
+enum TagUpdateMode {
+  NONE = 0;
+  // sets all tags
+  SET = 1;
+  // adds (or replaces if already present) tags
+  ADD = 2;
+}
+
 message UpdateVMRequest {
   string exp = 1;
   string name = 2;
@@ -77,6 +85,8 @@ message UpdateVMRequest {
   }
 
   uint32 inject_partition = 10 [json_name="inject_partition"];
+  TagUpdateMode tag_update_mode = 11 [json_name="tag_update_mode"];
+  map<string, string> tags = 12;
 }
 
 message UpdateVMRequestList {

--- a/src/js/src/components/RunningExperiment.vue
+++ b/src/js/src/components/RunningExperiment.vue
@@ -754,6 +754,18 @@
                 {{ props.row.uptime | uptime }}
               </template>
             </b-table-column>
+            <b-table-column label="Labels" centered v-slot="props">
+                <template>
+                  <b-tooltip label="View/Edit Labels" type="is-dark">
+                    <div @click="showTagsModal( props.row )" class="is-clickable">
+                      <font-awesome-layers full-width>
+                        <font-awesome-icon  icon="tag" />
+                        <font-awesome-layers-text counter :value="tagCount(props.row.tags)" />
+                      </font-awesome-layers>
+                    </div>
+                  </b-tooltip>
+                </template>
+              </b-table-column>
           </b-table>
           <br>
           <b-field v-if="paginationNeeded" grouped position="is-right">
@@ -841,6 +853,8 @@
 <script>
   import { mapState }        from 'vuex';
   import VmMountBrowserModal from './VMMountBrowserModal.vue';
+  import VmLabelsModal from './VMLabelsModal.vue';
+
 
   import _ from 'lodash';
 
@@ -1001,6 +1015,16 @@
         this.filesTable.defaultSortDirection = order;
         this.updateFiles();
       }, 
+
+      showTagsModal ( vm ) {
+        this.$buefy.modal.open({
+          parent:       this,
+          component:    VmLabelsModal,
+          trapFocus:    true,
+          hasModalCard: true,
+          props:        {"vmName": vm.name, "experiment": this.$route.params.id, "tags": vm.tags}
+        })
+      },
 
       handler ( event ) {
         event.data.split( /\r?\n/ ).forEach( m => {
@@ -3335,7 +3359,10 @@
 </script>
 
 <style scoped>
-div.autocomplete >>> a.dropdown-item {
-  color:  #383838 !important;
-}
+  div.autocomplete >>> a.dropdown-item {
+    color:  #383838 !important;
+  }
+  .fa-layers-counter { /* counter on tag icon */
+    transform: scale(.7) translateX(50%) translateY(-50%);
+  }
 </style>

--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -275,20 +275,35 @@
                 </template>
               </b-table-column>
               <b-table-column field="inject_partition" label="Partition" sortable centered v-slot="props">
-                  <template v-if="!props.row.external && roleAllowed('vms', 'patch', experiment.name + '/' + props.row.name)">
-                    <b-tooltip label="menu for assigning inject partition" type="is-dark">
-                      <b-select :value="props.row.inject_partition" expanded @input="( value ) => assignPartition( props.row.name, value )">
-                        <option v-for="n in 10" :value="n">{{ n }}</option>
-                      </b-select>
-                    </b-tooltip>
-                  </template>
-                  <template v-else>
-                    {{ props.row.inject_partition }}
-                  </template>
+                <template v-if="!props.row.external && roleAllowed('vms', 'patch', experiment.name + '/' + props.row.name)">
+                  <b-tooltip label="menu for assigning inject partition" type="is-dark">
+                    <b-select :value="props.row.inject_partition" expanded @input="( value ) => assignPartition( props.row.name, value )">
+                      <option value="1">1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                      <option value="4">4</option>
+                    </b-select>
+                  </b-tooltip>
+                </template>
+                <template v-else>
+                  {{ props.row.inject_partition }}
+                </template>
+              </b-table-column>
+              <b-table-column label="Labels" centered v-slot="props">
+                <template>
+                  <b-tooltip label="View/Edit Labels" type="is-dark">
+                    <div @click="showTagsModal( props.row )" class="is-clickable">
+                      <font-awesome-layers full-width>
+                        <font-awesome-icon  icon="tag" />
+                        <font-awesome-layers-text counter :value="tagCount(props.row.tags)" />
+                      </font-awesome-layers>
+                    </div>
+                  </b-tooltip>
+                </template>
               </b-table-column>
               <b-table-column label="Boot" centered v-slot="props">
                 <template v-if="roleAllowed('vms', 'patch', experiment.name + '/' + props.row.name)">
-                  <b-tooltip :label="getBootLabel( props.row )" type="is-dark">
+                  <b-tooltip :label="getBootLabel( props.row )" type="is-dark" class="is-clickable">
                     <div @click="updateDnb( props.row )">
                       <font-awesome-icon :class="bootDecorator( props.row )" icon="bolt" />
                     </div>
@@ -389,6 +404,7 @@
 
 <script>
   import _ from 'lodash';
+  import VmLabelsModal from './VMLabelsModal.vue';
 
   export default {
     beforeDestroy () {
@@ -1093,6 +1109,16 @@
         })
       },
 
+      showTagsModal ( vm ) {
+        this.$buefy.modal.open({
+          parent:       this,
+          component:    VmLabelsModal,
+          trapFocus:    true,
+          hasModalCard: true,
+          props:        {"vmName": vm.name, "experiment": this.$route.params.id, "tags": vm.tags}
+        })
+      },
+
       updateDnb ( vm ) {
         if (vm.external) {
           return;
@@ -1439,5 +1465,9 @@
 
   div.autocomplete >>> a.dropdown-item {
     color: #383838 !important;
+  }
+
+  .fa-layers-counter { /* counter on tag icon */
+    transform: scale(.7) translateX(50%) translateY(-50%);
   }
 </style>

--- a/src/js/src/components/VMLabelsModal.vue
+++ b/src/js/src/components/VMLabelsModal.vue
@@ -1,0 +1,201 @@
+<template>
+    <div class="modal-card" style="width: auto;">
+      <header class="modal-card-head">
+        <p class="modal-card-title mr-6">{{this.vmName}} Labels</p>
+      </header>
+      <section class="modal-card-body fixed-height">
+        <p class="title is-4">Notes</p>
+        <b-table :data="workingNotes" ref="notesTable">
+          <b-table-column field="value" label="Value" v-slot="props">
+              <template v-if="canEdit()">
+                <textarea class="textarea has-fixed-size" rows="1" v-model="props.row.value" @input="resizeNoteTextArea(`note${props.index}`)" @keypress="(evt) => noteKeyHandler(evt, `note${props.index}`)" :ref="`note${props.index}`"></textarea>
+              </template>
+              <template v-else>
+                {{ props.row.value }}
+              </template>
+          </b-table-column>
+          <b-table-column v-slot="props" v-if="canEdit()" width="32px">
+            <div @click="deleteNote( props.row )" class="is-clickable">
+              <font-awesome-icon icon="trash" />
+            </div>
+          </b-table-column>
+          <template #footer v-if="canEdit()">
+            <b-button icon-right="plus" type="is-text" size="is-small" expanded @click="addNote()"/>
+          </template>
+        </b-table>
+        <hr>
+        <p class="title is-4">Labels</p>
+        <b-table :data="workingTags">
+          <b-table-column field="key" label="Key" v-slot="props" width="192px">
+              <template v-if="canEdit()">
+                <b-input v-model="props.row.key" v-on:keyup.native.enter="addTag()" :ref="`tagKey${props.index}`"/>
+              </template>
+              <template v-else>
+                {{ props.row.key }}
+              </template>
+          </b-table-column>
+          <b-table-column field="value" label="Value" v-slot="props" width="512px">
+            <template v-if="canEdit()">
+                <b-input v-model="props.row.value" v-on:keyup.native.enter="addTag()"/>
+              </template>
+              <template v-else>
+                {{ props.row.value }}
+              </template>
+          </b-table-column>
+          <b-table-column v-slot="props" v-if="canEdit()" width="32px">
+            <div @click="deleteTag( props.row )" class="is-clickable">
+              <font-awesome-icon icon="trash" />
+            </div>
+          </b-table-column>
+          <template #footer v-if="canEdit()">
+            <b-button icon-right="plus" type="is-text" size="is-small" expanded @click="addTag()"/>
+          </template>
+        </b-table>
+      </section>
+      <footer class="modal-card-foot buttons is-right">
+        <b-button label="Close" @click="$emit('close')" />
+        <b-button v-if="canEdit()" label="Save" type="is-primary" @click="save()"/>
+      </footer>
+    </div>
+  </template>
+  
+  <script>
+  const NOTES_KEY = "__notes_"
+  export default {
+    props: {
+      vmName: String,
+      experiment: String,
+      tags: Object
+    },
+  
+    data() {
+      return {
+        workingTags: [],
+        workingNotes: [],
+      }
+    },
+  
+    beforeDestroy() {
+    },
+  
+    beforeMount() {
+      // copy tags object into an array of key,values for ui use
+      for (const [key, value] of Object.entries(this.tags)) {
+        if (key.startsWith("__")) {
+          if (key.startsWith(NOTES_KEY)) {
+            this.workingNotes.push({"key": key, "value": value})
+          }
+        }
+        else {
+          this.workingTags.push({"key": key, "value": value})
+        }
+      }
+      // start with blank space
+      if (this.workingTags.length == 0) {
+        this.addTag()
+      }
+      if (this.workingNotes.length == 0) {
+        this.addNote()
+      }
+
+      this.$nextTick(() => {
+        for(let i = 0; i < this.workingNotes.length; i++) {
+          this.resizeNoteTextArea(`note${i}`)
+        }
+      })
+    },
+  
+  
+    methods: {
+      canEdit() {
+        return this.roleAllowed('vms', 'patch', this.$route.params.id + "/" + this.vmName)
+      },
+      deleteTag(row) {
+        this.workingTags = this.workingTags.filter(e => e !== row)
+      },
+      addTag() {
+        this.workingTags.push({"key": "", "value": ""})
+        this.$nextTick(() => {
+          this.$refs[`tagKey${this.workingTags.length - 1}`].focus()
+        })
+      },
+      deleteNote(row) {
+        this.workingNotes = this.workingNotes.filter(e => e !== row)
+      },
+      addNote() {
+        this.workingNotes.push({"key": NOTES_KEY + new Date().toISOString(), "value": ""})
+        this.$nextTick(() => {
+          this.$refs[`note${this.workingNotes.length - 1}`].focus()
+        })
+      },
+      resizeNoteTextArea(ref) {
+        const textArea = this.$refs[ref]
+        textArea.style.height = "auto";
+        this.$nextTick(() => {
+          textArea.style.height = textArea.scrollHeight + 'px';
+        })
+      },
+      noteKeyHandler(evt, ref) {
+        if (evt.key === "Enter" && evt.shiftKey) {
+          this.addNote()
+          evt.preventDefault()
+        }
+        else {
+          this.resizeNoteTextArea(ref)
+        }
+      },
+      save() {
+        var finalTags = {}
+        for (const row of this.workingTags) {
+          if (row.key == "" || row.key in finalTags)
+            continue
+          finalTags[row.key] = row.value
+        }
+
+        for (const row of this.workingNotes) {
+          if (row.key == "" || row.key in finalTags)
+            continue
+          finalTags[row.key] = row.value
+        }
+
+        let update = { "tag_update_mode": "SET", "tags": finalTags };
+
+        if (_.isEqual(finalTags, this.tags)) {
+          console.log("No change made. Closing")
+          this.$emit('close')
+          return;
+        }
+
+        this.$http.patch('experiments/' + this.$route.params.id + '/vms/' + this.vmName, update)
+            .then(response => {
+              if (response.ok) {
+                this.$emit('saved')
+                this.$emit('close')
+              }
+            }, err => {
+              this.errorNotification(err)
+            });
+      }
+    }
+  }
+  </script>
+    
+  <style scoped>
+    .fixed-height {
+      height: 75vh;
+      overflow: auto;
+    }
+
+    .b-table {
+      .table {
+        td {
+          vertical-align: middle;
+        }
+      }
+    }
+
+    textarea {
+      overflow-y: hidden;
+    }
+  
+  </style>

--- a/src/js/src/main.js
+++ b/src/js/src/main.js
@@ -15,11 +15,13 @@ import { roleAllowed } from './rbac'
 
 import { fas }             from '@fortawesome/free-solid-svg-icons'
 import { library }         from '@fortawesome/fontawesome-svg-core'
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { FontAwesomeIcon, FontAwesomeLayers, FontAwesomeLayersText } from '@fortawesome/vue-fontawesome'
 
 library.add(fas)
 
 Vue.component( 'font-awesome-icon', FontAwesomeIcon )
+Vue.component( 'font-awesome-layers', FontAwesomeLayers )
+Vue.component( 'font-awesome-layers-text', FontAwesomeLayersText )
 
 Vue.config.productionTip = false
 
@@ -91,13 +93,13 @@ Vue.filter( 'fileSize', function (fileSize) {
   }
 })
 
-Vue.prototype.errorNotification = errorNotification;
-Vue.errorNotification = errorNotification;
-const roleAllowedWrapper = (resource, verb, ...names) => {
-  return roleAllowed(store.getters.role, resource, verb, ...names)
-}
-Vue.prototype.roleAllowed = roleAllowedWrapper;
-Vue.roleAllowed = roleAllowedWrapper;
+Vue.mixin({
+  methods: {
+    roleAllowed: (resource, verb, ...names) => roleAllowed(store.getters.role, resource, verb, ...names),
+    errorNotification: errorNotification,
+    tagCount: (tags) => Object.keys(tags).filter(entry => !entry.startsWith("__") || entry.startsWith("__notes_")).length
+  }
+})
 
 Vue.http.options.root = `${process.env.BASE_URL}api/v1/`
 


### PR DESCRIPTION
This adds a few features in the UI for making notes and customizing the way a VM appears in the SOH graph. The intent is to make it easier for users to track/manage the status of VMs within an experiment (e.g., a user may mark a node red and add a note "reached by red team")


* Adds a new modal for viewing/editing the labels of a VM
  * Separate "notes" section that allows multiline, maintains insertion order, and hides key
  * Available in experiment pages and SOH
  * Treats minimega tags and phenix labels as one (meaning persistent across experiment runs, and also available in mm cli)

* Changes SOH details modal to show notes at the top
  * Adds buttons to edit labels and override style
  * New style modal lets user override the fill color, stroke color, and stroke style of a node. This takes precedence over any default styling

![labels_modal](https://github.com/sandialabs/sceptre-phenix/assets/86626873/3e0ed795-b207-4470-87f6-7d2c264254ba)
![style_modal](https://github.com/sandialabs/sceptre-phenix/assets/86626873/7968240d-9d3c-4d1e-9b21-9bcb558c13ad)
