### PR TITLE
[UI] Fix infinite waiting when updating disks

### DIFF
--- a/src/js/src/components/RunningExperiment.vue
+++ b/src/js/src/components/RunningExperiment.vue
@@ -1541,24 +1541,20 @@
     
       updateDisks (diskType="")  {
         this.disks = [];
-      
+        this.isWaiting = true
+
         this.$http.get( `disks?diskType=${diskType}` ).then(
           response  => {
             response.json().then(
-              state =>  {
-                if ( state.disks.length == 0 ) {
-                  this.isWaiting  = true;
-                } else {
-                  for ( let i = 0;  i < state.disks.length; i++ ) {
-                    this.disks.push( state.disks[i] );
-                  }
-                  
-                  this.isWaiting  = false;
+              state => {
+                this.isWaiting = false
+
+                for ( let i = 0;  i < state.disks.length; i++ ) {
+                  this.disks.push( state.disks[i] );
                 }
               }
             );
           },  err => {
-            console.log('Getting the disks failed with ' + err.status);
             this.isWaiting = false;
             this.errorNotification(err);
           }

--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -671,23 +671,23 @@
       },
       
       updateDisks () {
+        this.isWaiting = true
+
         this.$http.get( 'disks' + '?expName=' + this.$route.params.id ).then(
           response => {
             response.json().then(
               state => {
-                if ( state.disks.length == 0 ) {
-                  this.isWaiting = true;
-                } else {
-                  for ( let i = 0; i < state.disks.length; i++ ) {
-                    this.disks.push( state.disks[ i ] );
-                  }
+                this.isWaiting = false
 
-                  this.disks.sort()
-                  this.isWaiting = false;
+                for ( let i = 0;  i < state.disks.length; i++ ) {
+                  this.disks.push( state.disks[i] );
                 }
+
+                this.disks.sort()
               }
             );
           }, err => {
+            this.isWaiting = false
             this.errorNotification(err);
           }
         );


### PR DESCRIPTION
In the StoppedExperiment view, if there are no qcow images (i.e. .qcow2, .qc2) in the minimega files directory (usually `/phenix/images`), then the waiting indicator would spin indefinitely.  Likewise, in the RunningExperiment view, when using the `ChangeOpticalDisc` feature, the waiting indicator would spin indefinitely if there were no ISOs in the minimega files directory.  This patch fixes the issue with the infinite waiting indicator.