### PR TITLE
fix: remove colons from filenames output by scorch

### DIFF
--- a/src/go/api/scorch/app.go
+++ b/src/go/api/scorch/app.go
@@ -165,7 +165,7 @@ func (this *Scorch) Running(ctx context.Context, exp *types.Experiment) error {
 	}
 
 	if _, err := os.Stat(runDir); err == nil {
-		archive := filepath.Join(exp.FilesDir(), fmt.Sprintf("scorch-run-%d_%s.tgz", runID, start.Format(time.RFC3339)))
+		archive := filepath.Join(exp.FilesDir(), fmt.Sprintf("scorch-run-%d_%s.tgz", runID, start.Format("2006-01-02T15-04-05Z0700")))
 
 		if err := util.CreateArchive(runDir, archive); err != nil {
 			errors = multierror.Append(errors, fmt.Errorf("archiving data generated for run %d: %w", runID, err))
@@ -364,7 +364,7 @@ func (this Scorch) recordInfo(runID int, runDir string, md store.ConfigMetadata,
 		mmVersion,
 	)
 
-	fileName := fmt.Sprintf("info-scorch-run-%d_%s.txt", runID, startTime.Format(time.RFC3339))
+	fileName := fmt.Sprintf("info-scorch-run-%d_%s.txt", runID, startTime.Format("2006-01-02T15-04-05Z0700"))
 
 	if err := os.MkdirAll(runDir, 0755); err != nil {
 		return fmt.Errorf("creating %s directory for scorch run %d: %w", runDir, runID, err)


### PR DESCRIPTION
Currently, scorch archive and info files are created using the start time in RFC3339 format, which includes colons. This causes issues with some OSes, where colons in filenames are not expected (ex. running `tar xzfv scorch-run-1_2024-07-03T23:02:41Z.tgz` will throw an error on linux systems).

All Golang [time.Format](https://go.dev/src/time/format.go) pre-defined layouts that include times also include colons, so this fix uses a custom format `2006-01-02T15-04-05Z0700`.

Alternatively `strings.ReplaceAll(startTime.Format(time.RFC3339, ":", "=")` could be used.