### PR TITLE
Allow dhcp proto for vrouter interfaces.

### DIFF
--- a/src/go/api/scorch/app.go
+++ b/src/go/api/scorch/app.go
@@ -165,7 +165,7 @@ func (this *Scorch) Running(ctx context.Context, exp *types.Experiment) error {
 	}
 
 	if _, err := os.Stat(runDir); err == nil {
-		archive := filepath.Join(exp.FilesDir(), fmt.Sprintf("scorch-run-%d_%s.tgz", runID, start.Format(time.RFC3339)))
+		archive := filepath.Join(exp.FilesDir(), fmt.Sprintf("scorch-run-%d_%s.tgz", runID, start.Format("2006-01-02T15-04-05Z0700")))
 
 		if err := util.CreateArchive(runDir, archive); err != nil {
 			errors = multierror.Append(errors, fmt.Errorf("archiving data generated for run %d: %w", runID, err))
@@ -364,7 +364,7 @@ func (this Scorch) recordInfo(runID int, runDir string, md store.ConfigMetadata,
 		mmVersion,
 	)
 
-	fileName := fmt.Sprintf("info-scorch-run-%d_%s.txt", runID, startTime.Format(time.RFC3339))
+	fileName := fmt.Sprintf("info-scorch-run-%d_%s.txt", runID, startTime.Format("2006-01-02T15-04-05Z0700"))
 
 	if err := os.MkdirAll(runDir, 0755); err != nil {
 		return fmt.Errorf("creating %s directory for scorch run %d: %w", runDir, runID, err)

--- a/src/go/app/vrouter.go
+++ b/src/go/app/vrouter.go
@@ -171,7 +171,7 @@ func (this *Vrouter) PreStart(ctx context.Context, exp *types.Experiment) error 
 		}
 
 		if strings.EqualFold(node.Hardware().OSType(), "linux") {
-			fmt.Printf("  === using OS Type 'linux' for Node Type %s is depricated ===\n", node.Type())
+			fmt.Printf("  === using OS Type 'linux' for Node Type %s is deprecated ===\n", node.Type())
 			fmt.Printf("  === use 'vyatta', 'vyos', or 'minirouter' OS type instead ===\n")
 		}
 

--- a/src/go/tmpl/templates/vyatta.tmpl
+++ b/src/go/tmpl/templates/vyatta.tmpl
@@ -11,7 +11,11 @@
 interfaces {
 {{ range $idx, $iface := $node.Network.Interfaces }}
     ethernet eth{{ $idx }} {
+        {{ if eq $iface.Proto "dhcp" }}
+        address dhcp
+        {{ else }}
         address {{ $iface.Address }}/{{ $iface.Mask }}
+        {{ end }}
         duplex auto
         {{ if and (ge $iface.MTU 68) (le $iface.MTU 16000) }}
         mtu {{ $iface.MTU }}


### PR DESCRIPTION
For vrouter, allow `proto: dhcp` in the topology interface definition. Also spelling fix.