### PR TITLE
Add optional --unix-socket-gid flag

### DIFF
--- a/src/go/cmd/ui.go
+++ b/src/go/cmd/ui.go
@@ -37,6 +37,7 @@ func newUICmd() *cobra.Command {
 				web.ServeMinimegaLogs(viper.GetString("ui.logs.minimega-path")),
 				web.ServeWithFeatures(viper.GetStringSlice("ui.features")),
 				web.ServeWithProxyAuthHeader(viper.GetString("ui.proxy-auth-header")),
+				web.ServeWithUnixSocketGid(viper.GetInt("unix-socket-gid")),
 			}
 
 			if endpoint := viper.GetString("ui.unix-socket-endpoint"); endpoint != "" {
@@ -153,6 +154,11 @@ func newUICmd() *cobra.Command {
 
 	cmd.Flags().MarkHidden("log-requests")
 	cmd.Flags().MarkHidden("log-full")
+
+	cmd.Flags().Int("unix-socket-gid", -1, "group id to allow writes to the unix socket")
+	cmd.Flags().MarkHidden("unix-socket-gid")
+	viper.BindPFlag("unix-socket-gid", cmd.Flags().Lookup("unix-socket-gid"))
+	viper.BindEnv("unix-socket-gid")
 
 	return cmd
 }

--- a/src/go/web/option.go
+++ b/src/go/web/option.go
@@ -35,6 +35,8 @@ type serverOptions struct {
 	proxyAuthHeader string
 
 	features map[string]bool
+
+	unixSocketGid int
 }
 
 func newServerOptions(opts ...ServerOption) serverOptions {
@@ -170,6 +172,12 @@ func ServeWithFeatures(f []string) ServerOption {
 				o.features[feature] = false
 			}
 		}
+	}
+}
+
+func ServeWithUnixSocketGid(g int) ServerOption {
+	return func(o *serverOptions) {
+		o.unixSocketGid = g
 	}
 }
 

--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -316,6 +316,16 @@ func Start(opts ...ServerOption) error {
 			return err
 		}
 
+		if o.unixSocketGid != -1 {
+			plog.Info("setting Unix socket group permissions", "gid", o.unixSocketGid)
+			if err = os.Chown(common.UnixSocket, -1, o.unixSocketGid); err != nil {
+				return err
+			}
+			if err := os.Chmod(common.UnixSocket, 0775); err != nil {
+				return err
+			}
+		}
+
 		go func() {
 			if err := server.Serve(listener); err != nil {
 				plog.Error("serving Unix socket", "err", err)


### PR DESCRIPTION
Adds an optional (and hidden) flag for specifying a group ID to apply group ownership to the unix-socket. Also sets the permissions to be group-writable. Use case: phenix starts from within a docker container as the `root` user, but normal users wish to be able to use the unix-socket to communicate with phenix (without having to switch to `root`). This allows the users to be a part of the group specified in the flag and have write access to the socket.

Normal (`--unix-socket-gid=1000`):
<img width="567" alt="Screenshot 2024-08-02 at 08 49 19" src="https://github.com/user-attachments/assets/ef6700d8-226f-4e74-bb46-ffd14a5668d2">

Error (`--unix-socket-gid=foobar`):
<img width="868" alt="Screenshot 2024-08-04 at 21 27 37" src="https://github.com/user-attachments/assets/aa9f641f-df06-4bee-9c87-fdfafae4321c">
