### PR TITLE
fix: don't automatically use GRE mesh when bridge name isn't phenix

### DIFF
--- a/docker/Dockerfile.minimega
+++ b/docker/Dockerfile.minimega
@@ -3,7 +3,7 @@
 ARG  MM_REV
 FROM ghcr.io/activeshadow/minimega/minimega:${MM_REV}
 
-ARG   MINIMEGA_REVISION
+ARG   MM_REV
 LABEL org.opencontainers.image.base.name="ghcr.io/activeshadow/minimega/minimega:${MM_REV}"
 ARG   PHENIX_REVISION=local-dev
 LABEL gov.sandia.phenix.revision="${PHENIX_REVISION}"

--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -557,7 +557,7 @@ func Start(ctx context.Context, opts ...StartOption) error {
 		// them. This cannot be done as part of the minimega script template since
 		// the VM taps (and thus bridges) do not get created until the overall
 		// minimega namespace is launched.
-		if exp.Spec.UseGREMesh() || exp.Spec.DefaultBridge() != "phenix" {
+		if exp.Spec.UseGREMesh() {
 			if err := mm.CreateBridge(mm.NS(exp.Metadata.Name), mm.Bridge(exp.Spec.DefaultBridge())); err != nil {
 				if !o.mmErrAsWarn {
 					mm.ClearNamespace(exp.Spec.ExperimentName())


### PR DESCRIPTION
Commit 7b80f40 incorrectly assumed users would always want to use the GRE mesh namespace bridge capability in minimega when the default bridge for an experiment was not `phenix` (the default).