### PR TITLE
feat: extend startup join domain to linux

### DIFF
--- a/src/go/tmpl/templates/linux_domain.tmpl
+++ b/src/go/tmpl/templates/linux_domain.tmpl
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "{{ .domain_controller.password }}" | realm join --user={{ .domain_controller.username }} {{ .domain_controller.domain }}


### PR DESCRIPTION
This adds the ability for linux hosts to join MS Active Directory domains using realmd (assumed to be already installed).

Some light refactoring of when we check for the startup app to do it once before all hosts, now that it is needed for both linux and windows boxes.