### PR TITLE
feat: support deleting files in disk injects

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           build-args: |
-            MM_MIN_REV=da0b90c
+            MM_MIN_REV=9f867b3
             PHENIX_COMMIT=${{ env.sha }}
             PHENIX_TAG=${{ env.branch }}
             APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}

--- a/.github/workflows/minimega.yml
+++ b/.github/workflows/minimega.yml
@@ -28,10 +28,10 @@ jobs:
           context: docker
           file: docker/Dockerfile.minimega
           build-args: |
-            MM_REV=da0b90c
+            MM_REV=9f867b3
             PHENIX_REVISION=${{ env.sha }}
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/minimega:da0b90c
+            ghcr.io/${{ github.repository }}/minimega:9f867b3
             ghcr.io/${{ github.repository }}/minimega:${{ env.sha }}
             ghcr.io/${{ github.repository }}/minimega:${{ env.branch }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Update GitHub workflow config to change the minimum version of minimega
 # required for use with phenix. This build stage is needed for making sure the
 # latest version of the minimega Python module is installed.
-ARG  MM_MIN_REV=c8e20a3
+ARG  MM_MIN_REV=9f867b3
 FROM ghcr.io/activeshadow/minimega/minimega:${MM_MIN_REV} AS minimega
 
 
@@ -170,7 +170,7 @@ COPY --from=gobuilder /phenix/src/go/bin/phenix-tunneler-* /opt/phenix/downloads
 
 # Update GitHub workflow config to change the minimum version of minimega
 # required for use with phenix.
-ARG   MM_MIN_REV=c8e20a3
+ARG   MM_MIN_REV=9f867b3
 LABEL gov.sandia.phenix.minimega-min-revision="ghcr.io/sandialabs/sceptre-phenix/minimega:${MM_MIN_REV}"
 
 WORKDIR /opt/phenix

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       args:
-        MM_MIN_REV: da0b90c
+        MM_MIN_REV: 9f867b3
         PHENIX_WEB_AUTH: disabled
         APPS_REPO: github.com/activeshadow/phenix-apps
         APPS_BRANCH: caldera
@@ -46,7 +46,7 @@ services:
       context: .
       dockerfile: Dockerfile.minimega
       args:
-        MM_REV: da0b90c
+        MM_REV: 9f867b3
     image: minimega
     container_name: minimega
     privileged: true

--- a/src/go/tmpl/templates/minimega_script.tmpl
+++ b/src/go/tmpl/templates/minimega_script.tmpl
@@ -31,10 +31,13 @@ ns add-host localhost
 ## DoNotBoot: {{ derefBool .General.DoNotBoot }} ##
     {{- else }}
         {{- if (derefBool .General.Snapshot) -}}
-        {{ $firstDrive := index .Hardware.Drives 0 }}
-disk snapshot {{ $firstDrive.Image }} {{ $.SnapshotName .General.Hostname }} 
+            {{ $firstDrive := index .Hardware.Drives 0 }}
+disk snapshot {{ $firstDrive.Image }} {{ $.SnapshotName .General.Hostname }}
             {{- if gt (len .Injections) 0 }}
 disk inject {{ $.SnapshotName .General.Hostname }}:{{ $firstDrive.GetInjectPartition }} files {{ .FileInjects $basedir }}
+            {{- end }}
+            {{- if gt (len .Deletions) 0 }}
+disk inject {{ $.SnapshotName .General.Hostname }}:{{ $firstDrive.GetInjectPartition }} delete files {{ .FileDeletions }}
             {{- end }}
         {{- end }}
 clear vm config

--- a/src/go/types/interfaces/topology.go
+++ b/src/go/types/interfaces/topology.go
@@ -29,6 +29,7 @@ type NodeSpec interface {
 	Hardware() NodeHardware
 	Network() NodeNetwork
 	Injections() []NodeInjection
+	Deletions() []NodeDeletion
 	Delay() NodeDelay
 	Advanced() map[string]string
 	Overrides() map[string]string
@@ -36,6 +37,7 @@ type NodeSpec interface {
 	External() bool
 
 	SetInjections([]NodeInjection)
+	SetDeletions([]NodeDeletion)
 	SetType(string)
 	SetLabels(map[string]string)
 
@@ -87,6 +89,7 @@ type NodeSpec interface {
 	//       	 - network: 75.75.0.0/16
 	AddNetworkOSPF(routerID string, dead, hello, retrans int, areas map[int][]string)
 	AddInject(string, string, string, string)
+	AddDeletion(string, string)
 
 	SetAdvanced(map[string]string)
 	AddAdvanced(string, string)
@@ -252,6 +255,11 @@ type NodeInjection interface {
 	Dst() string
 	Description() string
 	Permissions() string
+}
+
+type NodeDeletion interface {
+	Path() string
+	Description() string
 }
 
 type NodeDelay interface {


### PR DESCRIPTION
Supports adding a keyword to the src field of a file injection to delete the file/directory in a disk image. E.g.

```yml
      injections:
        - src: TERMINATED
          dst: /ProgramData/Microsoft/Windows Defender
```

Depends on https://github.com/sandia-minimega/minimega/pull/1548