### PR TITLE
Upgrade pip in phenix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,6 +148,10 @@ RUN wget -O filebeat.deb https://artifacts.elastic.co/downloads/beats/filebeat/f
 ARG PIP_INDEX="https://pypi.org/"
 ARG PIP_INDEX_URL="https://pypi.org/simple"
 
+# Upgrade pip. Ubuntu 22 python3-pip package is pip 22
+# 23+ is needed to effectively support pyproject.toml
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+
 # Do this before installing phenix-apps so minimega package is latest version
 COPY --from=minimega /opt/minimega/lib /tmp/minimega
 RUN python3 -m pip install --no-cache-dir /tmp/minimega

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,8 @@ services:
       - ui
       - --hostname-suffixes=-minimega,-phenix
       - --logs.minimega-path=/var/log/phenix/minimega.log
-      - --logs.publish-to-ui=info
+      # NOTE: setting this to INFO or below may lead to UI lag in certain scenarios
+      - --logs.publish-to-ui=error
       - --minimega-console
     image: phenix
     container_name: phenix
@@ -38,6 +39,12 @@ services:
       - ./tmp/minimega:/tmp/minimega
       - ./tmp/phenix:/tmp/phenix
     environment:
+      # MM_FILEPATH is the base path for minimega
+      # Used for disk images (.qc2) and also where
+      # miniccc responses get saved to. For example,
+      # for an experiment named "foo", the miniccc
+      # responses will be saved to the directory
+      # /phenix/images/foo/miniccc_responses
       MM_FILEPATH: /phenix/images
     depends_on:
       - minimega
@@ -65,6 +72,7 @@ services:
     healthcheck:
       test: mm version
     environment:
+      # Ensure this matches MM_FILEPATH in phenix service (defined above)
       MM_FILEPATH: /phenix/images
       MM_LOGFILE: /var/log/phenix/minimega.log
       MM_LOGLEVEL: info

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@ x-common: &common
     options:
       max-file: "5"
       max-size: "10m"
+
 services:
   phenix:
     build:
@@ -16,10 +17,12 @@ services:
         MM_MIN_REV: 9f867b3
         PHENIX_WEB_AUTH: disabled
     command:
-    - phenix
-    - ui
-    - --hostname-suffixes=-minimega,-phenix
-    - --minimega-console
+      - phenix
+      - ui
+      - --hostname-suffixes=-minimega,-phenix
+      - --logs.minimega-path=/var/log/phenix/minimega.log
+      - --logs.publish-to-ui=info
+      - --minimega-console
     image: phenix
     container_name: phenix
     privileged: true
@@ -34,6 +37,8 @@ services:
       - /phenix:/phenix:shared
       - ./tmp/minimega:/tmp/minimega
       - ./tmp/phenix:/tmp/phenix
+    environment:
+      MM_FILEPATH: /phenix/images
     depends_on:
       - minimega
     healthcheck:


### PR DESCRIPTION
Upgrade the version of pip during phenix image build. This enables use of pyproject.toml. Shouldn't be needed whenever we upgrade to Ubuntu 24 as base image in the future.

Also added some args to docker-compose to enable logging in phenix UI.