### PR TITLE
feat: support disabling of VNC banners for VMs

### DIFF
--- a/src/go/web/vnc.go
+++ b/src/go/web/vnc.go
@@ -122,6 +122,8 @@ type vncConfig struct {
 
 	TopBanner    bannerConfig `mapstructure:"topBanner"`
 	BottomBanner bannerConfig `mapstructure:"bottomBanner"`
+
+	Disabled bool `mapstructure:"disabled"`
 }
 
 func newVNCBannerConfig(token, exp, vm string) *vncConfig {
@@ -148,11 +150,13 @@ func (this *vncConfig) finalize(banner ...string) {
 		return
 	}
 
-	if len(this.TopBanner.BannerLines) > 0 {
-		this.TopBanner.Banner = template.HTML(strings.Join(this.TopBanner.BannerLines, "<br/>"))
-	}
+	if !this.Disabled {
+		if len(this.TopBanner.BannerLines) > 0 {
+			this.TopBanner.Banner = template.HTML(strings.Join(this.TopBanner.BannerLines, "<br/>"))
+		}
 
-	if len(this.BottomBanner.BannerLines) > 0 {
-		this.BottomBanner.Banner = template.HTML(strings.Join(this.BottomBanner.BannerLines, "<br/>"))
+		if len(this.BottomBanner.BannerLines) > 0 {
+			this.BottomBanner.Banner = template.HTML(strings.Join(this.BottomBanner.BannerLines, "<br/>"))
+		}
 	}
 }


### PR DESCRIPTION
Adds ability to disable banners for a specific VM using the existing VNC banner annotation via a newly added disabled setting. Note that this will disable both the top and bottom banner.

```
annotations:
  vncBanner:
    disabled: true
```