### PR TITLE
feat(auth): Add user configurable settings + password requirements 

### DIFF
--- a/src/go/api/settings/defaults.go
+++ b/src/go/api/settings/defaults.go
@@ -1,0 +1,94 @@
+package settings
+
+import (
+	"fmt"
+	"phenix/store"
+	"phenix/types"
+	v2 "phenix/types/version/v2"
+	"strconv"
+
+	"github.com/activeshadow/structs"
+)
+
+var DEFAULT_SETTINGS = []v2.Setting{
+	{Category: "Password", Name: "NumberReq", Type: v2.SettingValueBool, Value: strconv.FormatBool(true)},
+	{Category: "Password", Name: "SymbolReq", Type: v2.SettingValueBool, Value: strconv.FormatBool(true)},
+	{Category: "Password", Name: "LowercaseReq", Type: v2.SettingValueBool, Value: strconv.FormatBool(true)},
+	{Category: "Password", Name: "UppercaseReq", Type: v2.SettingValueBool, Value: strconv.FormatBool(false)},
+	{Category: "Password", Name: "MinLength", Type: v2.SettingValueInt, Value: formatInt(8)},
+}
+
+func GetDefault(category, name string) (v2.Setting, bool) {
+	for _, setting := range DEFAULT_SETTINGS {
+		if setting.Category == category && setting.Name == name {
+			return setting, true
+		}
+	}
+	return v2.Setting{}, false
+}
+
+func SetDefaults() error {
+	for _, spec := range DEFAULT_SETTINGS {
+		//create ignores if the setting exists already
+
+		settingName := GetStoreName(spec.Category, spec.Name)
+
+		c := store.Config{
+			Version: "phenix.sandia.gov/v2",
+			Kind:    "Setting",
+			Metadata: store.ConfigMetadata{
+				Name: settingName,
+			},
+			Spec: structs.MapDefaultCase(&spec, structs.CASESNAKE),
+		}
+
+		if err := store.Create(&c); err != nil {
+			return fmt.Errorf("storing setting %s: %w", settingName, err)
+		}
+	}
+	return nil
+}
+
+func setMissingDefaults(existing []types.Setting) ([]types.Setting, error) {
+
+	var fullSettings []types.Setting
+	fullSettings = append(fullSettings, existing...)
+
+	for _, spec := range DEFAULT_SETTINGS {
+		if existsAlready(spec.Name, spec.Category, existing) {
+			continue
+		}
+
+		settingName := GetStoreName(spec.Category, spec.Name)
+
+		c := store.Config{
+			Version: "phenix.sandia.gov/v2",
+			Kind:    "Setting",
+			Metadata: store.ConfigMetadata{
+				Name: settingName,
+			},
+			Spec: structs.MapDefaultCase(&spec, structs.CASESNAKE),
+		}
+
+		if err := store.Create(&c); err != nil {
+			return nil, fmt.Errorf("storing setting %s: %w", settingName, err)
+		}
+
+		newSetting := types.Setting{Metadata: c.Metadata, Spec: &spec}
+
+		fullSettings = append(fullSettings, newSetting)
+
+	}
+
+	return existing, nil
+}
+
+func existsAlready(name, category string, existing []types.Setting) bool {
+	for _, exist := range existing {
+		if exist.Spec.Name == name && exist.Spec.Category == category {
+			//already exists
+			return true
+		}
+	}
+	return false
+}

--- a/src/go/api/settings/passwords.go
+++ b/src/go/api/settings/passwords.go
@@ -1,0 +1,185 @@
+package settings
+
+import (
+	"fmt"
+	"phenix/types"
+	"phenix/util/plog"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+//Set custom hard coded limits on settings here
+
+const (
+	MAX_PASSWORD_MIN_LEN = 32
+	MIN_PASSWORD_MIN_LEN = 8
+)
+
+type PasswordSettings struct {
+	LowercaseReq bool  `json:"lowercase_req"`
+	UppercaseReq bool  `json:"uppercase_req"`
+	NumberReq    bool  `json:"number_req"`
+	SymbolReq    bool  `json:"symbol_req"`
+	MinLength    int32 `json:"min_length"`
+}
+
+func GetPasswordSettings() (PasswordSettings, error) {
+	plog.Debug("Getting all password settings")
+
+	settings, err := List()
+	if err != nil {
+		return PasswordSettings{}, fmt.Errorf("error getting list: %w", err)
+	}
+
+	return GetPasswordSettingsFromList(settings)
+}
+
+func GetPasswordSettingsFromList(settings []types.Setting) (PasswordSettings, error) {
+	passwordSettings := PasswordSettings{}
+	var err error
+
+	for _, setting := range settings {
+		category := setting.Spec.Category
+		name := setting.Spec.Name
+
+		if category != "Password" {
+			continue
+		}
+		switch name {
+		case "NumberReq":
+			passwordSettings.NumberReq, err = strconv.ParseBool(setting.Spec.Value)
+			if err != nil {
+				return passwordSettings, fmt.Errorf("Error parsing %s.%s setting: %w", category, name, err)
+			}
+		case "SymbolReq":
+			passwordSettings.SymbolReq, err = strconv.ParseBool(setting.Spec.Value)
+			if err != nil {
+				return passwordSettings, fmt.Errorf("Error parsing %s.%s setting: %w", category, name, err)
+			}
+		case "LowercaseReq":
+			passwordSettings.LowercaseReq, err = strconv.ParseBool(setting.Spec.Value)
+			if err != nil {
+				return passwordSettings, fmt.Errorf("Error parsing %s.%s setting: %w", category, name, err)
+			}
+		case "UppercaseReq":
+			passwordSettings.UppercaseReq, err = strconv.ParseBool(setting.Spec.Value)
+			if err != nil {
+				return passwordSettings, fmt.Errorf("Error parsing %s.%s setting: %w", category, name, err)
+			}
+		case "MinLength":
+			passwordSettings.MinLength, err = parseInt(setting.Spec.Value)
+			if err != nil {
+				return passwordSettings, fmt.Errorf("Error parsing %s.%s setting: %w", category, name, err)
+			}
+		}
+	}
+	return passwordSettings, nil
+}
+
+func UpdatePasswordSettings(newSettings PasswordSettings) error {
+	plog.Debug("Updating password settings")
+
+	var err error
+	_, err = Update("Password", "NumberReq", strconv.FormatBool(newSettings.NumberReq))
+	if err != nil {
+		return fmt.Errorf("Error updating Settings.NumberReq: %w", err)
+	}
+	_, err = Update("Password", "SymbolReq", strconv.FormatBool(newSettings.SymbolReq))
+	if err != nil {
+		return fmt.Errorf("Error updating Settings.SymbolReq: %w", err)
+	}
+	_, err = Update("Password", "LowercaseReq", strconv.FormatBool(newSettings.LowercaseReq))
+	if err != nil {
+		return fmt.Errorf("Error updating Settings.LowercaseReq: %w", err)
+	}
+	_, err = Update("Password", "UppercaseReq", strconv.FormatBool(newSettings.UppercaseReq))
+	if err != nil {
+		return fmt.Errorf("Error updating Settings.UppercaseReq: %w", err)
+	}
+
+	minLen := newSettings.MinLength
+	if minLen > MAX_PASSWORD_MIN_LEN || minLen < MIN_PASSWORD_MIN_LEN {
+		return fmt.Errorf("Minimum password length must be between %d and %d", MIN_PASSWORD_MIN_LEN, MAX_PASSWORD_MIN_LEN)
+	}
+	_, err = Update("Password", "MinLength", formatInt(newSettings.MinLength))
+	if err != nil {
+		return fmt.Errorf("Error updating Settings.MinLength: %w", err)
+	}
+
+	plog.Debug("Updated password settings successfully")
+	return nil
+}
+
+func IsPasswordValid(password string) bool {
+	plog.Debug("Checking if password is valid")
+	ps, err := GetPasswordSettings()
+	if err != nil {
+		plog.Error("Error checking IsPasswordValid: ", "err", err)
+		return false
+	}
+	if len(password) < int(ps.MinLength) {
+		return false
+	}
+
+	var lower bool
+	var upper bool
+	var number bool
+	var symbol bool
+
+	for _, c := range password {
+		switch {
+		case unicode.IsNumber(c):
+			number = true
+		case unicode.IsLower(c):
+			lower = true
+		case unicode.IsUpper(c):
+			upper = true
+		case unicode.IsSymbol(c) || unicode.IsPunct(c):
+			symbol = true
+		}
+	}
+
+	//if req is false, want to default to true. if req is true, need var to be true
+	res := (lower || !ps.LowercaseReq)
+	res = res && (upper || !ps.UppercaseReq)
+	res = res && (number || !ps.NumberReq)
+	res = res && (symbol || !ps.SymbolReq)
+
+	return res
+}
+
+func GetPasswordSettingsHTML() string {
+	settings, err := GetPasswordSettings()
+	if err != nil {
+		return ""
+	}
+
+	var rules []string
+	rules = append(rules, fmt.Sprintf("Password requires %d characters", settings.MinLength))
+
+	if settings.LowercaseReq {
+		rules = append(rules, "Password requires a lowercase letter")
+	}
+	if settings.UppercaseReq {
+		rules = append(rules, "Password requires an uppercase letter")
+	}
+	if settings.NumberReq {
+		rules = append(rules, "Password requires a number")
+	}
+	if settings.SymbolReq {
+		rules = append(rules, "Password requires a symbol")
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("<ol>")
+	for _, rule := range rules {
+		sb.WriteString("<li>")
+		sb.WriteString(rule)
+		sb.WriteString("</li>")
+	}
+	sb.WriteString("</ol>")
+
+	return sb.String()
+}

--- a/src/go/api/settings/settings.go
+++ b/src/go/api/settings/settings.go
@@ -1,0 +1,218 @@
+package settings
+
+import (
+	"fmt"
+	"phenix/store"
+	"phenix/types"
+	v2 "phenix/types/version/v2"
+	"phenix/util/plog"
+	"strconv"
+
+	"github.com/activeshadow/structs"
+	"github.com/mitchellh/mapstructure"
+)
+
+/*
+Adding a new setting:
+
+1. Add to 'Settings' struct in settings.go
+2. Add to DEFAULT_SETTINGS in defaults.go
+3. Update Getter and Setter functions
+	- If category already exists
+		- add to settings category file (i.e. password.go)
+		- update GET and UPDATE functions
+	- If category is new
+		- create new file for the categroy, make Get and Update function
+		- Add new category to GetSettings and UpdateAllSettings (settings.go)
+4. Update Settings.vue for UI visibility
+*/
+
+type Settings struct {
+	PasswordSettings PasswordSettings `json:"password_settings"`
+}
+
+func GetSettings() (*Settings, error) {
+	plog.Debug("Getting all settings")
+	settings := &Settings{}
+	var err error
+
+	settingList, err := List()
+	if err != nil {
+		return nil, fmt.Errorf("Error listing settings: %w", err)
+	}
+
+	settings.PasswordSettings, err = GetPasswordSettingsFromList(settingList)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting password settings: %v", err)
+	}
+
+	return settings, nil
+}
+
+func UpdateAllSettings(newSettings Settings) error {
+	plog.Debug("Updating all settings")
+
+	if err := UpdatePasswordSettings(newSettings.PasswordSettings); err != nil {
+		return fmt.Errorf("Error updating password settings: %w", err)
+	}
+
+	return nil
+}
+
+func GetStoreName(category, name string) string {
+	return fmt.Sprintf("%s.%s", category, name)
+}
+
+func Update(category, name, value string) (bool, error) {
+	plog.Debug("Updating setting", "category", category, "name", name, "value", value)
+	oldSetting, err := GetSetting(category, name)
+	if err != nil {
+		return false, fmt.Errorf("Error getting existing setting: %v", err)
+	}
+
+	settingName := GetStoreName(category, name)
+
+	if oldSetting.Spec.Value == value {
+		//don't need to update
+		return false, nil
+	}
+	oldSetting.Spec.Value = value
+
+	c := store.Config{
+		Version: "phenix.sandia.gov/v2",
+		Kind:    "Setting",
+		Metadata: store.ConfigMetadata{
+			Name: settingName,
+		},
+		Spec: structs.MapDefaultCase(&oldSetting.Spec, structs.CASESNAKE),
+	}
+
+	if err := store.Update(&c); err != nil {
+		return false, fmt.Errorf("storing setting %s: %w", settingName, err)
+	}
+
+	return true, nil
+}
+
+// Same as update but verify the value is of the correct type
+func UpdateWithVerification(category, name, value string) error {
+	plog.Debug("Updating setting with verification", "category", category, "name", name, "value", value)
+	oldSetting, err := GetSetting(category, name)
+	if err != nil {
+		return fmt.Errorf("Error getting existing setting: %v", err)
+	}
+
+	settingName := GetStoreName(category, name)
+
+	if oldSetting.Spec.Value == value {
+		// don't need to update
+		return nil
+	}
+
+	if ok, err := verify(oldSetting.Spec.Type, value); !ok {
+		return fmt.Errorf("error verifying setting: %w", err)
+	}
+
+	oldSetting.Spec.Value = value
+
+	c := store.Config{
+		Version: "phenix.sandia.gov/v2",
+		Kind:    "Setting",
+		Metadata: store.ConfigMetadata{
+			Name: settingName,
+		},
+		Spec: structs.MapDefaultCase(&oldSetting.Spec, structs.CASESNAKE),
+	}
+
+	if err := store.Update(&c); err != nil {
+		return fmt.Errorf("storing setting %s: %w", settingName, err)
+	}
+
+	return nil
+}
+
+func verify(settingType v2.SettingValueType, value string) (bool, error) {
+	plog.Debug("Verifying setting", "type", settingType, "value", value)
+	switch settingType {
+	case v2.SettingValueBool:
+		_, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, fmt.Errorf("error parsing bool: %w", err)
+		}
+	case v2.SettingValueInt:
+		_, err := parseInt(value)
+		if err != nil {
+			return false, fmt.Errorf("error parsing int: %w", err)
+		}
+	case v2.SettingValueFloat:
+		_, err := parseFloat(value)
+		if err != nil {
+			return false, fmt.Errorf("error parsing float: %w", err)
+		}
+	}
+	return true, nil
+}
+
+func List() ([]types.Setting, error) {
+	plog.Debug("Listing all settings")
+	configs, err := store.List("Setting")
+	if err != nil {
+		return nil, fmt.Errorf("getting list of settings from store: %w", err)
+	}
+
+	var settings []types.Setting
+
+	for _, c := range configs {
+		spec := new(v2.Setting)
+		if err := mapstructure.Decode(c.Spec, spec); err != nil {
+			return nil, fmt.Errorf("decoding image spec: %w", err)
+		}
+
+		sett := types.Setting{Metadata: c.Metadata, Spec: spec}
+		settings = append(settings, sett)
+	}
+
+	if len(settings) < len(DEFAULT_SETTINGS) {
+		return setMissingDefaults(settings)
+	}
+
+	return settings, nil
+}
+
+func GetSetting(category, name string) (*types.Setting, error) {
+	plog.Debug("Getting setting", "category", category, "name", name)
+
+	combined := fmt.Sprintf("%s.%s", category, name)
+	c, _ := store.NewConfig("setting/" + combined)
+
+	if err := store.Get(c); err != nil {
+		return nil, fmt.Errorf("getting setting config %s from store: %w", name, err)
+	}
+
+	spec := new(v2.Setting)
+	if err := mapstructure.Decode(c.Spec, spec); err != nil {
+		return nil, fmt.Errorf("decoding image spec: %w", err)
+	}
+
+	sett := &types.Setting{Metadata: c.Metadata, Spec: spec}
+
+	return sett, nil
+}
+
+// for consistent parsing / formatting
+func parseInt(value string) (int32, error) {
+	i, err := strconv.ParseInt(value, 10, 32)
+	return int32(i), err
+}
+
+func parseFloat(value string) (float64, error) {
+	return strconv.ParseFloat(value, 64)
+}
+
+func formatFloat(value float64) string {
+	return strconv.FormatFloat(value, 'g', -1, 64)
+}
+
+func formatInt(value int32) string {
+	return strconv.FormatInt(int64(value), 10)
+}

--- a/src/go/cmd/settings.go
+++ b/src/go/cmd/settings.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"phenix/api/settings"
+	"phenix/util"
+	"phenix/util/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func newSettingsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "settings",
+		Short: "View or edit phenix settings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	return cmd
+}
+
+func newSettingsListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List phenix settings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			s, err := settings.List()
+			if err != nil {
+				err := util.HumanizeError(err, "Unable to print a table")
+				return err.Humanized()
+			}
+
+			printer.PrintTableOfSettings(os.Stdout, s)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newSettingsEditCmd() *cobra.Command {
+	example := `
+  phenix setting edit <category> <name> <newValue>
+  phenix setting edit Password MinLength 20`
+
+	cmd := &cobra.Command{
+		Use:     "edit",
+		Short:   "Edit a phenix setting",
+		Example: example,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(args) < 1 {
+				return fmt.Errorf("Must provide a setting category")
+			} else if len(args) < 2 {
+				return fmt.Errorf("Must provide a setting name")
+			} else if len(args) < 3 {
+				return fmt.Errorf("Must provide a setting value")
+			} else if len(args) > 3 {
+				return fmt.Errorf("Must only provide a setting category, name and value. If the value is a string, please use quotes.")
+			}
+
+			category := args[0]
+			name := args[1]
+			value := args[2]
+
+			err := settings.UpdateWithVerification(category, name, value)
+			if err != nil {
+				err := util.HumanizeError(err, "Error updating setting")
+				return err.Humanized()
+			}
+
+			return nil
+		},
+	}
+	return cmd
+}
+
+func init() {
+	settingsCmd := newSettingsCmd()
+	settingsCmd.AddCommand(newSettingsListCmd())
+	settingsCmd.AddCommand(newSettingsEditCmd())
+	rootCmd.AddCommand(settingsCmd)
+}

--- a/src/go/types/settings.go
+++ b/src/go/types/settings.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+	"phenix/store"
+	v2 "phenix/types/version/v2"
+)
+
+type Setting struct {
+	Metadata store.ConfigMetadata `json:"metadata" yaml:"metadata"`
+	Spec     *v2.Setting          `json:"spec" yaml:"spec"`
+}

--- a/src/go/types/version/v2/settings.go
+++ b/src/go/types/version/v2/settings.go
@@ -1,0 +1,17 @@
+package v2
+
+type SettingValueType string
+
+const (
+	SettingValueInt    SettingValueType = "int"
+	SettingValueFloat  SettingValueType = "float64"
+	SettingValueBool   SettingValueType = "bool"
+	SettingValueString SettingValueType = "string"
+)
+
+type Setting struct {
+	Category string           `json:"category" yaml:"category"`
+	Name     string           `json:"name" yaml:"name"`
+	Value    string           `json:"value" yaml:"value"`
+	Type     SettingValueType `json:"type" yaml:"type"`
+}

--- a/src/go/util/printer/printer.go
+++ b/src/go/util/printer/printer.go
@@ -242,3 +242,30 @@ func PrintTableOfSubnetCaptures(writer io.Writer, captures []mm.Capture) {
 
 	table.Render()
 }
+
+func PrintTableOfSettings(writer io.Writer, settings []types.Setting) {
+	var (
+		table = tablewriter.NewWriter(writer)
+		cols  = []string{"Name", "Category", "Value"}
+	)
+
+	table.SetHeader(cols)
+
+	table.SetColumnAlignment([]int{
+		tablewriter.ALIGN_DEFAULT,
+		tablewriter.ALIGN_DEFAULT,
+		tablewriter.ALIGN_RIGHT,
+	})
+
+	for _, setting := range settings {
+		row := []string{
+			setting.Spec.Name,
+			setting.Spec.Category,
+			setting.Spec.Value,
+		}
+
+		table.Append(row)
+	}
+
+	table.Render()
+}

--- a/src/go/web/auth.go
+++ b/src/go/web/auth.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"phenix/api/settings"
 	"phenix/util/plog"
 	"phenix/web/rbac"
 	"phenix/web/util"
@@ -62,7 +63,19 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if !settings.IsPasswordValid(req.Password) {
+		plog.Error("password does not meet requirements")
+		errStr := fmt.Sprintf("password does not meet the requirements:\n%s", settings.GetPasswordSettingsHTML())
+		http.Error(w, errStr, http.StatusBadRequest)
+		return
+	}
+
 	u := rbac.NewUser(req.Username, req.Password)
+	if u == nil {
+		//can happen if username is the same as an existing user
+		http.Error(w, "error creating user", http.StatusInternalServerError)
+		return
+	}
 
 	u.Spec.FirstName = req.FirstName
 	u.Spec.LastName = req.LastName

--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -23,6 +23,7 @@ import (
 	"phenix/api/config"
 	"phenix/api/experiment"
 	"phenix/api/scenario"
+	"phenix/api/settings"
 	"phenix/api/vm"
 	"phenix/app"
 	"phenix/store"
@@ -1060,7 +1061,7 @@ func UpdateVM(w http.ResponseWriter, r *http.Request) {
 	case *proto.UpdateVMRequest_Host:
 		opts = append(opts, vm.UpdateWithHost(req.GetHost()))
 	}
-	
+
 	switch req.SnapshotOption.(type) {
 	case *proto.UpdateVMRequest_Snapshot:
 		opts = append(opts, vm.UpdateWithSnapshot(req.GetSnapshot()))
@@ -3025,4 +3026,86 @@ func parseInt(v string, d *int) error {
 	var err error
 	*d, err = strconv.Atoi(v)
 	return err
+}
+
+// GET /settings
+func GetSettings(w http.ResponseWriter, r *http.Request) {
+	plog.Debug("HTTP Handler called", "handler", "GetSettings")
+
+	settings, err := settings.GetSettings()
+	if err != nil {
+		plog.Error("getting proto settings", "err:", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	body, err := json.Marshal(settings)
+	if err != nil {
+		plog.Error("marshaling settings", "err:", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.Write(body)
+}
+
+// POST /settings
+func SetSettings(w http.ResponseWriter, r *http.Request) {
+	plog.Debug("HTTP handler called", "handler", "SetSettings")
+
+	var (
+		ctx  = r.Context()
+		role = ctx.Value("role").(rbac.Role)
+	)
+
+	if !role.Allowed("settings", "update") {
+		plog.Warn("setting settings not allowed", "user", ctx.Value("user").(string))
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		plog.Error("reading request body", "err", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	s := &settings.Settings{}
+	err = json.Unmarshal(body, s)
+	if err != nil {
+		plog.Error("Unmarshaling request body", "err", err)
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	err = settings.UpdateAllSettings(*s)
+	if err != nil {
+		plog.Error("Updating all settings", "err", err)
+		http.Error(w, "Error updating settings", http.StatusInternalServerError)
+		return
+	}
+	plog.Info("settings changed", "user", ctx.Value("user").(string))
+}
+
+// GET /settings/password
+func GetPasswordRequirements(w http.ResponseWriter, r *http.Request) {
+	plog.Debug("HTTP handler called", "handler", "GetPasswordRequirements")
+	settings.SetDefaults()
+
+	passwordReqs, err := settings.GetPasswordSettings()
+	if err != nil {
+		plog.Error("Getting password settings:", "err", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	body, err := json.Marshal(passwordReqs)
+	if err != nil {
+		plog.Error("Marshalling password reqs:", "err", err)
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	w.Write(body)
 }

--- a/src/go/web/rbac/known_policy.go
+++ b/src/go/web/rbac/known_policy.go
@@ -46,6 +46,7 @@ var Permissions = []Permission{
 	{"roles", "list"},
 	{"scenarios", "list"},
 	{"schemas", "get"},
+	{"settings", "update"},
 	{"topologies", "list"},
 	{"users", "create"},
 	{"users", "delete"},

--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -246,6 +246,10 @@ func Start(opts ...ServerOption) error {
 	api.HandleFunc("/console/{pid}/ws", WsConsole).Methods("GET", "OPTIONS")
 	api.HandleFunc("/console/{pid}/size", ResizeConsole).Methods("POST", "OPTIONS").Queries("cols", "{cols:[0-9]+}", "rows", "{rows:[0-9]+}")
 
+	api.HandleFunc("/settings", GetSettings).Methods("GET", "OPTIONS")
+	api.HandleFunc("/settings", SetSettings).Methods("POST", "OPTIONS")
+	api.HandleFunc("/settings/password", GetPasswordRequirements).Methods("GET", "OPTIONS")
+
 	workflowRoutes := []route{
 		{"/workflow/apply/{branch}", weberror.ErrorHandler(ApplyWorkflow), []string{"POST"}},
 		{"/workflow/configs/{branch}", weberror.ErrorHandler(WorkflowUpsertConfig), []string{"POST"}},

--- a/src/js/src/components/Header.vue
+++ b/src/js/src/components/Header.vue
@@ -43,6 +43,9 @@ are only available to Global Administrator or Global Viewer.
           <menu-link v-if="auth && tunneler"
                         :to="{name: 'tunneler'}"
                         class="navbar-item">Tunneler</menu-link>
+          <menu-link v-if="auth && roleAllowed('settings', 'edit')"
+                        :to="{name: 'settings'}"
+                        class="navbar-item">Settings</menu-link>
         </div>
       </div>
 

--- a/src/js/src/components/Settings.vue
+++ b/src/js/src/components/Settings.vue
@@ -1,0 +1,112 @@
+<template>
+  <section>
+    <hr>
+    <div class="settings-section">
+      <form class="content">
+        <h3>Password Settings</h3>
+        <b-field>
+          <b-switch v-model="settings_obj.password_settings.lowercase_req" >
+            Require a lowercase letter 
+          </b-switch>
+        </b-field>
+        <b-field>
+          <b-switch v-model="settings_obj.password_settings.uppercase_req">
+            Require an uppercase letter 
+          </b-switch>
+        </b-field>
+        <b-field>
+          <b-switch v-model="settings_obj.password_settings.number_req">
+            Require a number
+          </b-switch>
+        </b-field>
+        <b-field>
+          <b-switch v-model="settings_obj.password_settings.symbol_req">
+            Require a symbol
+          </b-switch>
+        </b-field>
+        <b-field>
+          Minimum length of password
+          <b-numberinput v-model="settings_obj.password_settings.min_length"
+            class="custom-small"
+            min="8"
+            max="32"
+            :controls="false">
+          </b-numberinput>
+        </b-field>
+        <hr>
+        <b-button @click="sendSettingsToServer">Save Changes</b-button>
+      </form>
+    </div>
+  </section>
+</template>
+<script>
+export default {
+
+  beforeDestroy () {
+  },
+  
+  async created () {
+    this.getSettings();
+  },
+
+  methods: {
+    getSettings(){
+      this.$http.get('settings').then(
+        response => {
+          response.json().then( state => {
+            // console.log(state)
+            this.settings_obj = state
+          })
+        }
+      )
+    },
+    printSettings(){
+      console.log(this.settings_obj)
+    },
+    sendSettingsToServer(){
+      this.$http.post(
+        'settings', this.settings_obj, { timeout: 0 }
+      ).then(
+          resp => {
+            // console.log(resp);
+            this.$buefy.toast.open({
+              message: "Settings updated",
+              type: 'is-success',
+              duration: 3000
+            });
+            
+          }, err => {
+            this.errorNotification(err);
+          }
+        )
+    },
+
+
+  },
+
+  data() {
+    return {
+      settings_obj: {
+        password_settings: {
+          number_req: false,
+          symbol_req: false,
+          lowercase_req: false,
+          uppercase_req: false,
+          min_length: 8,
+        },
+      },
+    };
+  },
+}
+</script>
+<style scoped>
+.settings-section {
+  padding: 10px;
+  margin: auto;
+  max-width: 800px;
+}
+.custom-small {
+  width: 25%;
+  min-width: 150px;
+}
+</style>

--- a/src/js/src/components/SignIn.vue
+++ b/src/js/src/components/SignIn.vue
@@ -14,19 +14,19 @@ It requires a valid email (user ID) and password.
           <b-field label="User Name" 
             :type="{ 'is-danger' : userExists }" 
             :message="{ 'User already exists' : userExists }">
-            <b-input type="text" v-model="username" minlength="4" maxlength="32" autofocus></b-input>
+            <b-input type="text" v-model="newUser.username" minlength="4" maxlength="32" autofocus></b-input>
           </b-field>
           <b-field label="First Name">
-            <b-input type="text" v-model="first_name"></b-input>
+            <b-input type="text" v-model="newUser.first_name"></b-input>
           </b-field>
           <b-field label="Last Name">
-            <b-input type="text" v-model="last_name"></b-input>
+            <b-input type="text" v-model="newUser.last_name"></b-input>
           </b-field>
           <b-field label="Password">
-            <b-input type="password" minlength="8" maxlength="32" v-model="password"></b-input>
+            <b-input type="password" minlength="8" maxlength="32" v-model="newUser.password"></b-input>
           </b-field>
           <b-field label="Confirm Password">
-            <b-input type="password" minlength="8" maxlength="32" v-model="confirmPassword" @keyup.native.enter="create"></b-input>
+            <b-input type="password" minlength="8" maxlength="32" v-model="newUser.confirmPassword" @keyup.native.enter="create"></b-input>
           </b-field>
         </section>
         <footer class="modal-card-foot buttons is-right">
@@ -118,7 +118,7 @@ It requires a valid email (user ID) and password.
       },
       
       create () {
-        if ( !this.username ) {
+        if ( !this.newUser.username ) {
           this.$buefy.toast.open({
             message: 'You must include an username',
             type: 'is-warning',
@@ -128,7 +128,7 @@ It requires a valid email (user ID) and password.
           return {}
         }
         
-        if ( !this.first_name ) {
+        if ( !this.newUser.first_name ) {
           this.$buefy.toast.open({
             message: 'You must include a first name',
             type: 'is-warning',
@@ -138,7 +138,7 @@ It requires a valid email (user ID) and password.
           return {}
         }
         
-        if ( !this.last_name ) {
+        if ( !this.newUser.last_name ) {
           this.$buefy.toast.open({
             message: 'You must include a last name',
             type: 'is-warning',
@@ -148,7 +148,7 @@ It requires a valid email (user ID) and password.
           return {}
         }
         
-        if ( !this.password ) {
+        if ( !this.newUser.password ) {
           this.$buefy.toast.open({
             message: 'You must include a password',
             type: 'is-warning',
@@ -158,7 +158,7 @@ It requires a valid email (user ID) and password.
           return {}
         }
         
-        if ( !this.confirmPassword ) {
+        if ( !this.newUser.confirmPassword ) {
           this.$buefy.toast.open({
             message: 'You must include a password confirmation',
             type: 'is-warning',
@@ -168,7 +168,7 @@ It requires a valid email (user ID) and password.
           return {}
         }
         
-        if ( this.password != this.confirmPassword ) {
+        if ( this.newUser.password != this.newUser.confirmPassword ) {
           this.$buefy.toast.open({
             message: 'Your passwords do not match',
             type: 'is-warning',
@@ -180,22 +180,28 @@ It requires a valid email (user ID) and password.
         
         this.$http.post(
           'signup', {
-            "username": this.username,
-            "password": this.password,
-            "first_name": this.first_name,
-            "last_name": this.last_name
+            "username": this.newUser.username,
+            "password": this.newUser.password,
+            "first_name": this.newUser.first_name,
+            "last_name": this.newUser.last_name
           }
         ).then(
           response => { 
             return response.json().then(
               user => {
                 this.$store.commit( 'SIGN_UP', user );
+                this.newUser = {
+                  username: null,
+                  password: null,
+                  confirmPassword: null,
+                  first_name: null,
+                  last_name: null,
+                }
               }
             )
           }, err => {
             this.errorNotification(err);
-            this.username = null;
-            this.password = null;
+            this.newUser.confirmPassword = null
           }
         );
 
@@ -208,11 +214,15 @@ It requires a valid email (user ID) and password.
         signUpModal: false,
         username: null,
         password: null,
-        confirmPassword: null,
-        first_name: null,
-        last_name: null,
         rememberMe: false,
-        userExists: false
+        userExists: false,
+        newUser: {
+          username: null,
+          password: null,
+          confirmPassword: null,
+          first_name: null,
+          last_name: null,
+        },
       }
     }
   }

--- a/src/js/src/router.js
+++ b/src/js/src/router.js
@@ -16,6 +16,7 @@ import Users         from './components/Users.vue'
 import VMtiles       from './components/VMtiles.vue'
 import MiniConsole   from './components/MiniConsole.vue'
 import Tunneler      from './components/Tunneler.vue'
+import Settings      from './components/Settings.vue'
 
 import store from './store'
 
@@ -51,6 +52,7 @@ const router = new Router({
     {path: '/vmtiles',           name: 'vmtiles',     component: VMtiles},
     {path: '/console',           name: 'console',     component: MiniConsole},
     {path: '/tunneler',          name: 'tunneler',    component: Tunneler},
+    {path: '/settings',          name: 'settings',    component: Settings},
 
     {path: '/builder?token=:token', name: 'builder'},
     {path: '/version',              name: 'version'},


### PR DESCRIPTION
# Add user configurable settings and password requirements

## Description
This PR adds two things: a framework for user configurable settings and password requirements for new users. 

It adds a settings page to the UI and two commands to the cli: `phenix settings list` and `phenix settings edit` for viewing and changing settings, respectively. Settings are a key/value pair where the value can be a bool, int, float, or string. The first batch of settings are password requirement settings for new users. The configurable password settings are as follows:
- minimum password length (int)
- lowercase letter requirement (bool)
- uppercase letter requirement (bool)
- symbol requirement (bool)
- number requirement (bool)

The password settings can be changed by admin users in the new 'settings' page of the UI or on the command line. Settings are saved in the phenix store and persist between sessions. Password settings are enforced on both front and back end. User creation / edit modals on the front end will not allow the user to submit a request if the password fails to conform to the rules. A check is also performed on the back end (in case a user skirts the front end requirement). 

If a user attempts to create an account from the 'SignIn' page as an unauthenticated user they will still need to have a password that passes the checks.


## Type of Change
New feature

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Example command line usage:
![Screenshot 2025-04-16 at 14 56 52](https://github.com/user-attachments/assets/e5b8c073-bf5a-4b88-badc-4a5ea6e78902)

Example UI screenshot:
![Screenshot 2025-04-16 at 14 45 17](https://github.com/user-attachments/assets/95ac4a17-3e48-4d56-b440-bc3999a740d5)

Example failed password requirement check:
![Screenshot 2025-04-16 at 14 45 56](https://github.com/user-attachments/assets/fc32207e-984e-49fb-a442-ccf738f2b6c5)