### PR TITLE
fix(Startup App): Add Auto Logon User to Local Admins

### DIFF
--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -157,8 +157,12 @@ if ($host_name -eq "{{ .Node.General.Hostname }}") {
     Set-ItemProperty -Path $path -Name DefaultPassword -Value "{{ index .Metadata "auto_logon" "password" }}"
         {{ if index .Metadata "auto_logon" "local" }}
     Set-ItemProperty -Path $path -Name DefaultDomainName -Value "."
+    Add-LocalGroupMember -Group "Administrators" -Member "{{ index .Metadata "auto_logon" "username" }}"
+
         {{ else }}
     Set-ItemProperty -Path $path -Name DefaultDomainName -Value $domain
+    Add-LocalGroupMember -Group "Administrators" -Member "$domain\{{ index .Metadata "auto_logon" "username" }}"
+
         {{ end }}
     Set-ItemProperty -Path $path -Name AutoAdminLogon -Value 1
     {{ end }}
@@ -179,8 +183,6 @@ if ($host_name -eq "{{ .Node.General.Hostname }}") {
     Set-ItemProperty -Path $path -Name DefaultPassword -Value "{{ index .Metadata "auto_logon" "password" }}"
     Set-ItemProperty -Path $path -Name DefaultDomainName -Value "."
     Set-ItemProperty -Path $path -Name AutoAdminLogon -Value 1
-
-    echo 'Adding auto logon user to Local Administrators group'
     Add-LocalGroupMember -Group "Administrators" -Member "{{ index .Metadata "auto_logon" "username" }}"
 
     Phenix-SetStartupStatus('auto-logon')

--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -161,7 +161,7 @@ if ($host_name -eq "{{ .Node.General.Hostname }}") {
 
         {{ else }}
     Set-ItemProperty -Path $path -Name DefaultDomainName -Value $domain
-    Add-LocalGroupMember -Group "Administrators" -Member "$domain\{{ index .Metadata "auto_logon" "username" }}"
+    Add-LocalGroupMember -Group "Administrators" -Member "{{ index .Metadata "auto_logon" "username" }}"
 
         {{ end }}
     Set-ItemProperty -Path $path -Name AutoAdminLogon -Value 1

--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -180,6 +180,9 @@ if ($host_name -eq "{{ .Node.General.Hostname }}") {
     Set-ItemProperty -Path $path -Name DefaultDomainName -Value "."
     Set-ItemProperty -Path $path -Name AutoAdminLogon -Value 1
 
+    echo 'Adding auto logon user to Local Administrators group'
+    Add-LocalGroupMember -Group "Administrators" -Member "{{ index .Metadata "auto_logon" "username" }}"
+
     Phenix-SetStartupStatus('auto-logon')
     Restart-Computer -Force
 {{ else }}


### PR DESCRIPTION
# Startup App - Add Auto Logon User to Local Admins

## Description
In instances where miniccc is started by an account that is not a
Local Administrator it fails. This addition ensures that the auto
logon user is added to the local machine's Administrators group which
allows miniccc access to global variables.

This obviously has security implications. I am not sure what the
'right' fix is, if we can change miniccc to work with reduced
privileges, but am opening an issue there too.

## Related Issue
- [minimega #1560](https://github.com/sandia-minimega/minimega/issues/1560)

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
