### PR TITLE
feat(schema): This adds an "other" os_type to the schema

### DIFF
--- a/src/go/types/version/v1/schema.go
+++ b/src/go/types/version/v1/schema.go
@@ -268,6 +268,7 @@ components:
               - vyatta
               - vyos
               - windows
+              - other
               default: linux
               example: windows
             drives:


### PR DESCRIPTION
# Adding an "Other" Operating System Type.

## Description
This adds an `"other"` `os_type` to the `Node.Hardware` schema.  There are several apps that use this property to make modifications to the launched VMs. These apps include (`startup`, `serial`, `ntp`, `vrouter`). Largely, these apps use the `OSType` for injecting files, but in some cases users may want to "opt out" of these automated behaviors. This additional `os_type` will enable this opt-out behavior.  Additionally, while having a strict schema is useful for some behaviors, this new category will enable niche OSes to be launched with Phenix without any other built-in assumptions about the system.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [ ] I have included no proprietary/sensitive information in my code. 
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.
