### PR TITLE
fix: update mm refs in docker and gh actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
     branches: ['**']
   repository_dispatch:
     types: [apps-update]
+env:
+  MM_REV: 6cf6cfb
 jobs:
   push-to-ghcr:
     name: Push phenix Docker image to GitHub Packages
@@ -17,27 +19,33 @@ jobs:
       - name: Get short SHA
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}/phenix
+          tags: |
+            type=ref,event=branch
+            type=sha
       - name: Build container image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: docker/Dockerfile
           build-args: |
-            MM_MIN_REV=9f867b3
+            MM_MIN_REV=${{ env.MM_REV }}
             PHENIX_COMMIT=${{ env.sha }}
-            PHENIX_TAG=${{ env.branch }}
+            PHENIX_TAG=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
             APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}/phenix:${{ env.sha }}
-            ghcr.io/${{ github.repository }}/phenix:${{ env.branch }}
+          tags: ${{ steps.meta.outputs.tags }}
+
   push-jit-to-ghcr:
     name: Push phenix JIT Docker image to GitHub Packages
     runs-on: ubuntu-latest
@@ -51,13 +59,20 @@ jobs:
       - name: Get short SHA
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}/phenix
+          tags: |
+            type=ref,event=branch
+            type=sha
       - name: Build container image
         uses: docker/build-push-action@v3
         with:
@@ -65,8 +80,7 @@ jobs:
           file: docker/jit/Dockerfile
           build-args: |
             PHENIX_REPO=${{ github.repository }}
-            PHENIX_TAG=${{ env.branch }}
+            PHENIX_IMG=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+            PHENIX_BRANCH=${{ github.head_ref || github.ref_name }} 
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}/phenix-jit-ui:${{ env.sha }}
-            ghcr.io/${{ github.repository }}/phenix-jit-ui:${{ env.branch }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/minimega.yml
+++ b/.github/workflows/minimega.yml
@@ -2,6 +2,8 @@ name: Publish minimega Docker image
 on:
   push:
     branches: ['**']
+env:
+  MM_REV: 6cf6cfb
 jobs:
   push-to-ghcr:
     name: Push minimega Docker image to GitHub Packages
@@ -15,23 +17,28 @@ jobs:
       - name: Get short SHA
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}/minimega
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=${{ env.MM_REV }}
       - name: Build container image
         uses: docker/build-push-action@v3
         with:
           context: docker
           file: docker/Dockerfile.minimega
           build-args: |
-            MM_REV=9f867b3
+            MM_REV=${{ env.MM_REV }}
             PHENIX_REVISION=${{ env.sha }}
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}/minimega:9f867b3
-            ghcr.io/${{ github.repository }}/minimega:${{ env.sha }}
-            ghcr.io/${{ github.repository }}/minimega:${{ env.branch }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # Update GitHub workflow config to change the minimum version of minimega
 # required for use with phenix. This build stage is needed for making sure the
 # latest version of the minimega Python module is installed.
-ARG  MM_MIN_REV=9f867b3
-FROM ghcr.io/activeshadow/minimega/minimega:${MM_MIN_REV} AS minimega
+ARG  MM_MIN_REV=6cf6cfb
+FROM ghcr.io/sandia-minimega/minimega:${MM_MIN_REV} AS minimega
 
 
 # ** jsbuilder **
@@ -167,7 +167,7 @@ COPY --from=gobuilder /phenix/src/go/bin/phenix-tunneler-* /opt/phenix/downloads
 
 # Update GitHub workflow config to change the minimum version of minimega
 # required for use with phenix.
-ARG   MM_MIN_REV=9f867b3
+ARG   MM_MIN_REV=6cf6cfb
 LABEL gov.sandia.phenix.minimega-min-revision="ghcr.io/sandialabs/sceptre-phenix/minimega:${MM_MIN_REV}"
 
 WORKDIR /opt/phenix

--- a/docker/Dockerfile.minimega
+++ b/docker/Dockerfile.minimega
@@ -1,10 +1,10 @@
 # Update GitHub workflow configs and docker-compose config to change the version
 # of minimega required for use with phenix.
 ARG  MM_REV
-FROM ghcr.io/activeshadow/minimega/minimega:${MM_REV}
+FROM ghcr.io/sandia-minimega/minimega:${MM_REV}
 
 ARG   MM_REV
-LABEL org.opencontainers.image.base.name="ghcr.io/activeshadow/minimega/minimega:${MM_REV}"
+LABEL org.opencontainers.image.base.name="ghcr.io/sandia-minimega/minimega:${MM_REV}"
 ARG   PHENIX_REVISION=local-dev
 LABEL gov.sandia.phenix.revision="${PHENIX_REVISION}"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       args:
-        MM_MIN_REV: 9f867b3
+        MM_MIN_REV: 6cf6cfb
         PHENIX_WEB_AUTH: disabled
     command:
     - phenix
@@ -43,7 +43,7 @@ services:
       context: .
       dockerfile: Dockerfile.minimega
       args:
-        MM_REV: 9f867b3
+        MM_REV: 6cf6cfb
     image: minimega
     container_name: minimega
     privileged: true

--- a/docker/jit/Dockerfile
+++ b/docker/jit/Dockerfile
@@ -1,11 +1,12 @@
 ARG PHENIX_REPO=sandialabs/sceptre-phenix
-ARG PHENIX_TAG=main
+ARG PHENIX_BRANCH=main
+ARG PHENIX_IMG=ghcr.io/${PHENIX_REPO}/phenix:${PHENIX_BRANCH}
 
-FROM ghcr.io/${PHENIX_REPO}/phenix:${PHENIX_TAG}
+FROM $PHENIX_IMG
 
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHENIX_REPO
-ARG PHENIX_TAG
+ARG PHENIX_BRANCH
 
 ENV NODE_VERSION 14.21.3
 
@@ -14,7 +15,7 @@ RUN wget -O node.txz https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSI
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 RUN npm install -g @vue/cli redoc-cli yarn
-RUN git clone --branch ${PHENIX_TAG} https://github.com/${PHENIX_REPO}.git /usr/local/src/phenix \
+RUN git clone --branch ${PHENIX_BRANCH} https://github.com/${PHENIX_REPO}.git /usr/local/src/phenix \
   && mkdir -p /opt/phenix/web \
   && cp -a /usr/local/src/phenix/src/go/web/public /opt/phenix/web
 

--- a/podman/pod.yml
+++ b/podman/pod.yml
@@ -31,7 +31,7 @@ spec:
           mountPath: /phenix
           mountPropagation: Bidirectional
     - name: minimega
-      image: ghcr.io/activeshadow/minimega/minimega:latest
+      image: ghcr.io/sandia-minimega/minimega:latest
       env:
         - name: MM_FILEPATH
           value: /phenix/images


### PR DESCRIPTION
## Description

* update mm rev to `6cf6cfb` to support disk changes
* change mm ref to main repo rather than a fork
* fix gh actions failing if branch had a '/' by using docker meta action to build tag names 
  * additional fixes to jit image following tag fix

## Related Issue
Follow on to PR #209 

## Type of Change
Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Did basic testing to verify images built and that disks page worked as expected
