### PR TITLE
fix: correct jit image name/build in GH actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,8 @@ jobs:
             APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+    outputs:
+      image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
 
   push-jit-to-ghcr:
     name: Push phenix JIT Docker image to GitHub Packages
@@ -69,7 +71,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}/phenix
+          images: ghcr.io/${{ github.repository }}/phenix-jit-ui
           tags: |
             type=ref,event=branch
             type=sha
@@ -80,7 +82,7 @@ jobs:
           file: docker/jit/Dockerfile
           build-args: |
             PHENIX_REPO=${{ github.repository }}
-            PHENIX_IMG=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+            PHENIX_IMG=${{ needs.push-to-ghcr.outputs.image }}
             PHENIX_BRANCH=${{ github.head_ref || github.ref_name }} 
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Description

Fixes an issue introduced in #228 where the JIT image was being published with the same name as the regular image in GitHub actions.

## Related Issue

Closes #233 

## Type of Change
Bugfix


## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
