### PR TITLE
feat: SoH startupDelay, fix: SoH empty address, ns path

### DIFF
--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -119,6 +119,8 @@ func (this *SOH) PreStart(ctx context.Context, exp *types.Experiment) error {
 }
 
 func (this *SOH) PostStart(ctx context.Context, exp *types.Experiment) error {
+	logger := plog.LoggerFromContext(ctx, plog.TypeSoh)
+
 	if err := this.decodeMetadata(exp); err != nil {
 		return err
 	}
@@ -136,6 +138,11 @@ func (this *SOH) PostStart(ctx context.Context, exp *types.Experiment) error {
 	if this.options.DryRun {
 		fmt.Printf("skipping SoH checks since this is a dry run")
 		return nil
+	}
+
+	if this.md.startupDelay > 0 {
+		logger.Info("Waiting before running SoH checks", "delay", this.md.startupDelay)
+		time.Sleep(this.md.startupDelay)
 	}
 
 	if err := this.runChecks(ctx, exp); err != nil {

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -121,6 +121,7 @@ type sohMetadata struct {
 	CustomReachability []customReachability        `mapstructure:"testCustomReachability"`
 	SkipNetworkConfig  bool                        `mapstructure:"skipInitialNetworkConfigTests"`
 	SkipHosts          []string                    `mapstructure:"skipHosts"`
+	StartupDelay       string                      `mapstructure:"startupDelay"`
 
 	// The `hostsToUseUUIDForC2Active` setting can be either a string or a slice
 	// of strings. Decoding `hostsToUseUUIDForC2Active` into `UseUUIDForC2Active`
@@ -131,8 +132,9 @@ type sohMetadata struct {
 	Other map[string]interface{} `mapstructure:",remain"`
 
 	// set after parsing
-	c2Timeout time.Duration
-	uuidHosts map[string]struct{}
+	c2Timeout    time.Duration
+	startupDelay time.Duration
+	uuidHosts    map[string]struct{}
 }
 
 func (this *sohMetadata) init() error {
@@ -162,6 +164,14 @@ func (this *sohMetadata) init() error {
 
 		if this.c2Timeout, err = time.ParseDuration(this.C2Timeout); err != nil {
 			return fmt.Errorf("parsing C2 timeout setting '%s': %w", this.C2Timeout, err)
+		}
+	}
+
+	// Default startup delay is 0 if not set
+	if this.StartupDelay != "" {
+		var err error
+		if this.startupDelay, err = time.ParseDuration(this.StartupDelay); err != nil {
+			return fmt.Errorf("parsing startup delay setting `%s`: %w", this.StartupDelay, err)
 		}
 	}
 


### PR DESCRIPTION
# feat: SoH startupDelay, fix: SoH empty address, ns path

## Description

One new feature and several fixes for SoH:

* **feat: `startupDelay`** (I am open to name changes) is a parameter that can be specified in order to delay SoH checks from running immediately at experiment start (or whenever the SoH app is reached). In every case that I have used SoH, I have found that it's first run in the experiment PostStart phase _always_ fails. This is due to various things, but basically "the experiment is still starting up, not all checks are going to work, yet".  This leads to a workflow of: start an experiment, wait for SoH to run in the PostStart phase (and fail), then manually run again either through the UI or CLI in order to get a "good" SoH check. Adding this delay allows slower configurations and processes to finish before SoH actually kicks off its checks, and when tunned can ensure that the first SoH run gives a "healthy" reading. This **will block** all other apps from completing, but SoH already blocks, and right now it is blocking for no reason because it always fails. This delay is only added to the PostStart phase, and does not affect later SoH runs in the Running phase.

* **fix:** if no address is set for a node in the topo, SoH no longer checks for a address. Previously SoH would check for a badly formated string (like `/0`) and fail.

* **fix:** revert a mistake I made in dfd9475 that incorrectly moved a miniccc file send path. This was based on testing with an outdated version of miniccc

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation. (https://github.com/sandialabs/sceptre-phenix-docs/pull/14)
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
