### PR TITLE
feat: parse env vars in phenix configs

### DIFF
--- a/src/go/api/config/config.go
+++ b/src/go/api/config/config.go
@@ -282,10 +282,6 @@ func Create(opts ...CreateOption) (*store.Config, error) {
 
 		data := string(o.data)
 
-		for _, v := range o.scopeVariables {
-			data = strings.ReplaceAll(data, v, o.scope)
-		}
-
 		switch o.dataType {
 		case DataTypeJSON:
 			c, err = store.NewConfigFromJSON([]byte(data))

--- a/src/go/api/config/config_test.go
+++ b/src/go/api/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"phenix/store"
@@ -36,7 +37,7 @@ func TestListError(t *testing.T) {
 	}
 }
 
-func TestCreateScoped(t *testing.T) {
+func TestCreateEnv(t *testing.T) {
 	expected := store.Config{
 		Version: "phenix.sandia.gov/v1",
 		Kind:    "Topology",
@@ -50,7 +51,7 @@ func TestCreateScoped(t *testing.T) {
 		"apiVersion": "phenix.sandia.gov/v1",
 		"kind": "Topology",
 		"metadata": {
-			"name": "{{BRANCH_NAME}}-test-experiment"
+			"name": "${BRANCH_NAME}-test-experiment"
 		}
 	}
 	`
@@ -63,7 +64,8 @@ func TestCreateScoped(t *testing.T) {
 
 	store.DefaultStore = m
 
-	options := []CreateOption{CreateFromJSON([]byte(cfg)), CreateWithScope("foobar")}
+	os.Setenv("BRANCH_NAME", "foobar")
+	options := []CreateOption{CreateFromJSON([]byte(cfg))}
 
 	_, err := Create(options...)
 	if err != nil {

--- a/src/go/api/config/option.go
+++ b/src/go/api/config/option.go
@@ -18,15 +18,10 @@ type createOptions struct {
 	data     []byte
 	dataType DataType
 	validate bool
-	scope    string
-
-	scopeVariables []string
 }
 
 func newCreateOptions(opts ...CreateOption) createOptions {
-	o := createOptions{
-		scopeVariables: []string{"{{BRANCH_NAME}}"},
-	}
+	var o createOptions
 
 	for _, opt := range opts {
 		opt(&o)
@@ -64,11 +59,5 @@ func CreateFromYAML(d []byte) CreateOption {
 func CreateWithValidation() CreateOption {
 	return func(o *createOptions) {
 		o.validate = true
-	}
-}
-
-func CreateWithScope(s string) CreateOption {
-	return func(o *createOptions) {
-		o.scope = s
 	}
 }

--- a/src/go/store/types.go
+++ b/src/go/store/types.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"phenix/types/version"
+	"phenix/util/common"
 
 	"gopkg.in/yaml.v3"
 )
@@ -66,6 +67,9 @@ func NewConfigFromFile(path string) (*Config, error) {
 		return nil, fmt.Errorf("cannot read config: %w", err)
 	}
 
+	// Parse environment variables in the file
+	file = []byte(common.ParseEnv(string(file)))
+
 	var c Config
 
 	switch filepath.Ext(path) {
@@ -88,19 +92,9 @@ func NewConfigFromFile(path string) (*Config, error) {
 	return &c, nil
 }
 
-func NewConfigFromJSON(body []byte, replacements ...string) (*Config, error) {
-	data := string(body)
-
-	// Starting at 1 handles the case where replacements has an odd number of
-	// entries.
-	for i := 1; i < len(replacements); i += 2 {
-		var (
-			tmpl = replacements[i-1]
-			val  = replacements[i]
-		)
-
-		data = strings.ReplaceAll(data, tmpl, val)
-	}
+func NewConfigFromJSON(body []byte) (*Config, error) {
+	// Parse environment variables in the file
+	data := common.ParseEnv(string(body))
 
 	var c Config
 
@@ -115,19 +109,9 @@ func NewConfigFromJSON(body []byte, replacements ...string) (*Config, error) {
 	return &c, nil
 }
 
-func NewConfigFromYAML(body []byte, replacements ...string) (*Config, error) {
-	data := string(body)
-
-	// Starting at 1 handles the case where replacements has an odd number of
-	// entries.
-	for i := 1; i < len(replacements); i += 2 {
-		var (
-			tmpl = replacements[i-1]
-			val  = replacements[i]
-		)
-
-		data = strings.ReplaceAll(data, tmpl, val)
-	}
+func NewConfigFromYAML(body []byte) (*Config, error) {
+	// Parse environment variables in the file
+	data := common.ParseEnv(string(body))
 
 	var c Config
 

--- a/src/go/web/workflow.go
+++ b/src/go/web/workflow.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"phenix/api/config"
@@ -54,6 +55,10 @@ func ApplyWorkflow(w http.ResponseWriter, r *http.Request) error {
 		cfg *store.Config
 	)
 
+	// set branch name in environment variable so it can be used in
+	// NewConfigFromJSON and NewConfigFromYAML
+	os.Setenv("BRANCH_NAME", scope)
+
 	switch {
 	case typ == "application/json": // default to JSON if not set
 		body, err := io.ReadAll(r.Body)
@@ -62,7 +67,8 @@ func ApplyWorkflow(w http.ResponseWriter, r *http.Request) error {
 			return err.SetStatus(http.StatusInternalServerError)
 		}
 
-		cfg, err = store.NewConfigFromJSON(body, "{{BRANCH_NAME}}", scope)
+		os.Setenv("BRANCH_NAME", scope)
+		cfg, err = store.NewConfigFromJSON(body)
 		if err != nil {
 			return weberror.NewWebError(err, "unable to parse phenix workflow config")
 		}
@@ -73,7 +79,7 @@ func ApplyWorkflow(w http.ResponseWriter, r *http.Request) error {
 			return err.SetStatus(http.StatusInternalServerError)
 		}
 
-		cfg, err = store.NewConfigFromYAML(body, "{{BRANCH_NAME}}", scope)
+		cfg, err = store.NewConfigFromYAML(body)
 		if err != nil {
 			return weberror.NewWebError(err, "unable to parse phenix workflow config")
 		}
@@ -361,6 +367,10 @@ func WorkflowUpsertConfig(w http.ResponseWriter, r *http.Request) error {
 		cfg *store.Config
 	)
 
+	// set branch name in environment variable so it can be used in
+	// NewConfigFromJSON and NewConfigFromYAML
+	os.Setenv("BRANCH_NAME", scope)
+
 	switch {
 	case typ == "application/json": // default to JSON if not set
 		body, err := io.ReadAll(r.Body)
@@ -369,7 +379,7 @@ func WorkflowUpsertConfig(w http.ResponseWriter, r *http.Request) error {
 			return err.SetStatus(http.StatusInternalServerError)
 		}
 
-		cfg, err = store.NewConfigFromJSON(body, "{{BRANCH_NAME}}", scope)
+		cfg, err = store.NewConfigFromJSON(body)
 		if err != nil {
 			return weberror.NewWebError(err, "unable to parse JSON config")
 		}
@@ -380,7 +390,7 @@ func WorkflowUpsertConfig(w http.ResponseWriter, r *http.Request) error {
 			return err.SetStatus(http.StatusInternalServerError)
 		}
 
-		cfg, err = store.NewConfigFromYAML(body, "{{BRANCH_NAME}}", scope)
+		cfg, err = store.NewConfigFromYAML(body)
 		if err != nil {
 			return weberror.NewWebError(err, "unable to parse YAML config")
 		}


### PR DESCRIPTION
# Support env vars in phenix configs

## Description
This PR adds support for using environment variables in phenix configs (YAML or JSON).

> [!WARNING]
> This change also converts the old `{{BRANCH_NAME}}` scoped variable for the [phenix workflow](https://github.com/sandialabs/sceptre-phenix?tab=readme-ov-file#git-workflow-support) to an environment variable `${BRANCH_NAME}`. The phenix workflow api calls and scripts remain unchanged, as the code handles passing the uri argument as an environment variable to the new config code. The only change that's required as part of this PR is that any reference to `{{BRANCH_NAME}}` should be changed to `${BRANCH_NAME}`

## Related Issue
n/a

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [X] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
On creation of a new phenix config, this code replaces any environment variable placeholders found in the config with their corresponding values. Placeholders are in the format ${VAR} or ${VAR:default}, where VAR is the environment variable name, and default is an optional default value to use if the variable is not set. If the environment variable is not found and no default is provided, the placeholder is replaced with an empty string.

Example config before parse:

```yaml
  - name: foobar
    metadata:
      baz:
        ip: ${HOST:localhost}
```

After parse with `HOST=172.20.0.33`:

```yaml
  - name: foobar
    metadata:
      baz:
        ip: 172.20.0.33
```

Or if `HOST` env variable isn't found, the default is used:

```yaml
  - name: foobar
    metadata:
      baz:
        ip: localhost
```
