### PR TITLE
fix: don't panic if user is sudo and actual user is not present

### DIFF
--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -242,7 +242,9 @@ func getCurrentUserInfo() (string, string) {
 	if u.Uid == "0" && sudo != "" {
 		u, err := user.Lookup(sudo)
 		if err != nil {
-			panic("unable to lookup sudo user: " + err.Error())
+			// fall back to sudo if we couldn't get actual user
+			fmt.Fprintf(os.Stderr, "Could not find SUDO_USER %s. Looking for optional config file in sudo home directory\n", sudo)
+			return uid, home
 		}
 
 		// `uid` and `home` will now reflect the user ID and home directory of the


### PR DESCRIPTION
# fix: don't panic if user is sudo and actual user is not present

## Description
Currently if the user is sudo, phenix tries to get the actual user through `user.Lookup`. It panics if that lookup returns nil; however, the function returns nil for LDAP users. As a result, phenix may unnecessarily panic in certain setups making it unusable.

The lookup is only used to look for a config file in the user's home directory, so this change just reverts to using the sudo user for this lookup.

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.