### PR TITLE
feat (startup): support C2 delivery for startup scripts

### DIFF
--- a/src/go/app/startup.go
+++ b/src/go/app/startup.go
@@ -5,29 +5,55 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
-
 	"phenix/tmpl"
 	"phenix/types"
-	ifaces "phenix/types/interfaces"
 	"phenix/util"
 	"phenix/util/common"
 	"phenix/util/mm"
 	"phenix/util/notes"
 	"phenix/util/plog"
 	"phenix/util/pubsub"
+
+	"github.com/mitchellh/mapstructure"
+
+	ifaces "phenix/types/interfaces"
 )
 
 const (
 	tunnelConfigPartsPortOnly     = 1
 	tunnelConfigPartsPortHost     = 2
 	tunnelConfigPartsPortHostDest = 3
+
+	startupViaCCAnnotation = "phenix/startup-via-cc"
+
+	linuxHostnameInjectDst  = "/etc/phenix/startup/1_hostname-start.sh"
+	linuxTimezoneInjectDst  = "/etc/phenix/startup/2_timezone-start.sh"
+	linuxIfaceInjectDst     = "/etc/phenix/startup/3_interfaces-start.sh"
+	linuxDomainInjectDst    = "/etc/phenix/startup/4_domain-start.sh"
+	windowsStartupInjectDst = "/phenix/startup/20-startup.ps1"
+
+	legacyWindowsStartupWrapperDst = "/phenix/phenix-startup.ps1"
+	windowsSchedulerDst            = "ProgramData/Microsoft/Windows/Start Menu/Programs/Startup/startup_scheduler.cmd"
 )
 
 type Startup struct{}
+
+type startupC2Executor string
+
+const (
+	startupC2Linux   startupC2Executor = "linux"
+	startupC2Windows startupC2Executor = "windows"
+)
+
+type commandSetter interface {
+	SetCommands([]string)
+}
+
+var startupMMFullPath = mm.GetMMFullPath //nolint:gochecknoglobals // overridden by tests
 
 func (Startup) Init(...Option) error {
 	return nil
@@ -39,6 +65,199 @@ func (Startup) Name() string {
 
 func (s *Startup) Configure(ctx context.Context, exp *types.Experiment) error {
 	return nil
+}
+
+// startupViaCCEnabled reports whether the startup app should use C2 delivery.
+func startupViaCCEnabled(node ifaces.NodeSpec) bool {
+	val, ok := node.GetAnnotation(startupViaCCAnnotation)
+	if !ok {
+		return false
+	}
+
+	switch v := val.(type) {
+	case bool:
+		return v
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "false", "0":
+			return false
+		default:
+			return true
+		}
+	case int, int64, float64:
+		return v != 0
+	default:
+		return true
+	}
+}
+
+// startupC2DeliveryEnabled reports whether generated startup scripts need C2 delivery.
+func startupC2DeliveryEnabled(node ifaces.NodeSpec) bool {
+	if node.General() != nil && node.General().DoNotBoot() != nil && *node.General().DoNotBoot() {
+		return false
+	}
+
+	return startupViaCCEnabled(node) || firstDriveInjectPartition(node) == 0
+}
+
+// firstDriveInjectPartition returns the first disk inject partition, defaulting to one.
+func firstDriveInjectPartition(node ifaces.NodeSpec) int {
+	if node.Hardware() == nil {
+		return 1
+	}
+
+	drives := node.Hardware().Drives()
+	if len(drives) == 0 {
+		return 1
+	}
+
+	part := drives[0].InjectPartition()
+	if part == nil {
+		return 1
+	}
+
+	return *part
+}
+
+// addStartupInject adds a startup app injection unless startup injection suppression is active.
+func addStartupInject(node ifaces.NodeSpec, src, dst string, suppress bool) {
+	if suppress {
+		return
+	}
+
+	node.AddInject(src, dst, "0644", "")
+}
+
+// addStartupC2Script stages a generated startup script and queues its C2 commands.
+func addStartupC2Script(exp *types.Experiment, node ifaces.NodeSpec, filename string, executor startupC2Executor) error {
+	send, exec, relPath := startupC2Commands(exp, filename, executor)
+	if err := stageStartupC2Script(filename, relPath); err != nil {
+		return fmt.Errorf("staging startup C2 script for node %s: %w", node.General().Hostname(), err)
+	}
+
+	node.AddCommand(send)
+	node.AddCommand(exec)
+
+	return nil
+}
+
+// stageStartupC2Script copies a generated startup script into minimega's file path.
+func stageStartupC2Script(src, relPath string) error {
+	dst := startupMMFullPath(relPath)
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return fmt.Errorf("creating startup C2 script directory: %w", err)
+	}
+
+	content, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("reading startup script: %w", err)
+	}
+
+	if err := os.WriteFile(dst, content, 0o600); err != nil {
+		return fmt.Errorf("writing startup C2 script: %w", err)
+	}
+
+	return nil
+}
+
+// startupC2Commands builds the minimega send and exec-once commands for a startup script.
+func startupC2Commands(exp *types.Experiment, filename string, executor startupC2Executor) (string, string, string) {
+	var (
+		relPath   = path.Join(exp.Spec.ExperimentName(), filepath.Base(filename))
+		guestPath = path.Join("/tmp/miniccc/files", relPath)
+
+		send = "send " + relPath
+	)
+
+	switch executor {
+	case startupC2Windows:
+		return send, fmt.Sprintf("exec-once cmd /c 'powershell.exe -noprofile -executionpolicy bypass -file %s'", guestPath), relPath
+	case startupC2Linux:
+		fallthrough
+	default:
+		return send, "exec-once bash " + guestPath, relPath
+	}
+}
+
+// removeStartupC2Commands removes previously generated startup C2 commands for idempotency.
+func removeStartupC2Commands(exp *types.Experiment, node ifaces.NodeSpec) {
+	setter, ok := node.(commandSetter)
+	if !ok {
+		return
+	}
+
+	stale := make(map[string]struct{})
+	for _, filename := range startupC2ScriptNames(node.General().Hostname()) {
+		for _, executor := range []startupC2Executor{startupC2Linux, startupC2Windows} {
+			send, exec, _ := startupC2Commands(exp, filename, executor)
+			stale[send] = struct{}{}
+			stale[exec] = struct{}{}
+		}
+	}
+
+	commands := node.Commands()
+	filtered := make([]string, 0, len(commands))
+
+	for _, command := range commands {
+		if _, ok := stale[command]; ok {
+			continue
+		}
+
+		filtered = append(filtered, command)
+	}
+
+	setter.SetCommands(filtered)
+}
+
+// startupC2ScriptNames returns the generated startup script names for a node.
+func startupC2ScriptNames(hostname string) []string {
+	return []string{
+		hostname + "-hostname.sh",
+		hostname + "-timezone.sh",
+		hostname + "-interfaces.sh",
+		hostname + "-domain.sh",
+		hostname + "-startup.ps1",
+	}
+}
+
+// removeStartupInjections removes only injections owned by the startup app.
+func removeStartupInjections(node ifaces.NodeSpec) {
+	removeInjectionDestinations(node, map[string]struct{}{
+		linuxHostnameInjectDst:  {},
+		linuxTimezoneInjectDst:  {},
+		linuxIfaceInjectDst:     {},
+		linuxDomainInjectDst:    {},
+		windowsStartupInjectDst: {},
+	})
+}
+
+// removeLegacyWindowsStartupInjections cleans stale startup-owned Windows
+// wrapper and Start Menu injections.
+// TODO: remove this migration helper after existing environments have had
+// enough startup runs to drop those old entries.
+func removeLegacyWindowsStartupInjections(node ifaces.NodeSpec) {
+	removeInjectionDestinations(node, map[string]struct{}{
+		legacyWindowsStartupWrapperDst: {},
+		windowsSchedulerDst:            {},
+		"/" + windowsSchedulerDst:      {},
+	})
+}
+
+// removeInjectionDestinations filters node injections whose destinations match dsts.
+func removeInjectionDestinations(node ifaces.NodeSpec, dsts map[string]struct{}) {
+	injections := node.Injections()
+	filtered := make([]ifaces.NodeInjection, 0, len(injections))
+
+	for _, injection := range injections {
+		if _, ok := dsts[injection.Dst()]; ok {
+			continue
+		}
+
+		filtered = append(filtered, injection)
+	}
+
+	node.SetInjections(filtered)
 }
 
 //nolint:cyclop,funlen,gocyclo,maintidx // complex logic
@@ -152,6 +371,16 @@ func (s Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 			))
 		}
 
+		useC2 := startupC2DeliveryEnabled(node)
+		suppressStartupInjects := startupViaCCEnabled(node)
+
+		removeStartupC2Commands(exp, node)
+		removeLegacyWindowsStartupInjections(node)
+
+		if suppressStartupInjects {
+			removeStartupInjections(node)
+		}
+
 		// if type is router, skip it and continue
 		if strings.EqualFold(node.Type(), "Router") {
 			continue
@@ -182,23 +411,9 @@ func (s Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 				ifaceFile    = startupDir + "/" + node.General().Hostname() + "-interfaces.sh"
 			)
 
-			node.AddInject(
-				hostnameFile,
-				"/etc/phenix/startup/1_hostname-start.sh",
-				"0755", "",
-			)
-
-			node.AddInject(
-				timezoneFile,
-				"/etc/phenix/startup/2_timezone-start.sh",
-				"0755", "",
-			)
-
-			node.AddInject(
-				ifaceFile,
-				"/etc/phenix/startup/3_interfaces-start.sh",
-				"0755", "",
-			)
+			addStartupInject(node, hostnameFile, linuxHostnameInjectDst, suppressStartupInjects)
+			addStartupInject(node, timezoneFile, linuxTimezoneInjectDst, suppressStartupInjects)
+			addStartupInject(node, ifaceFile, linuxIfaceInjectDst, suppressStartupInjects)
 
 			timeZone := "Etc/UTC"
 
@@ -221,16 +436,26 @@ func (s Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 				return fmt.Errorf("generating linux interfaces script: %w", err)
 			}
 
+			if useC2 {
+				if err := addStartupC2Script(exp, node, hostnameFile, startupC2Linux); err != nil {
+					return err
+				}
+
+				if err := addStartupC2Script(exp, node, timezoneFile, startupC2Linux); err != nil {
+					return err
+				}
+
+				if err := addStartupC2Script(exp, node, ifaceFile, startupC2Linux); err != nil {
+					return err
+				}
+			}
+
 			if startupApp != nil {
 				for _, host := range startupApp.Hosts() {
 					if host.Hostname() == node.General().Hostname() {
 						domainFile := startupDir + "/" + node.General().Hostname() + "-domain.sh"
 
-						node.AddInject(
-							domainFile,
-							"/etc/phenix/startup/4_domain-start.sh",
-							"0755", "",
-						)
+						addStartupInject(node, domainFile, linuxDomainInjectDst, suppressStartupInjects)
 
 						err := tmpl.CreateFileFromTemplate(
 							"linux_domain.tmpl",
@@ -240,6 +465,12 @@ func (s Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 						if err != nil {
 							return fmt.Errorf("generating linux domain script: %w", err)
 						}
+
+						if useC2 {
+							if err := addStartupC2Script(exp, node, domainFile, startupC2Linux); err != nil {
+								return err
+							}
+						}
 					}
 				}
 			}
@@ -247,39 +478,7 @@ func (s Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 		case osWindows:
 			startupFile := startupDir + "/" + node.General().Hostname() + "-startup.ps1"
 
-			node.AddInject(
-				startupFile,
-				"/phenix/startup/20-startup.ps1",
-				"0755", "",
-			)
-
-			if incl, ok := node.GetAnnotation(
-				"includes-phenix-startup",
-			); !ok || incl == "false" ||
-				incl == false {
-				node.AddInject(
-					startupDir+"/phenix-startup.ps1",
-					"/phenix/phenix-startup.ps1",
-					"0755", "",
-				)
-
-				err := tmpl.RestoreAsset(startupDir, "phenix-startup.ps1")
-				if err != nil {
-					return fmt.Errorf("restoring phenix startup script: %w", err)
-				}
-
-				node.AddInject(
-					startupDir+"/startup-scheduler.cmd",
-					"ProgramData/Microsoft/Windows/Start Menu/Programs/Startup/startup_scheduler.cmd",
-					"0755",
-					"",
-				)
-
-				err = tmpl.RestoreAsset(startupDir, "startup-scheduler.cmd")
-				if err != nil {
-					return fmt.Errorf("restoring windows startup scheduler: %w", err)
-				}
-			}
+			addStartupInject(node, startupFile, windowsStartupInjectDst, suppressStartupInjects)
 
 			// Temporary struct to send to the Windows Startup template.
 			data := struct {
@@ -304,6 +503,12 @@ func (s Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 			if err != nil {
 				return fmt.Errorf("generating windows startup script: %w", err)
 			}
+
+			if useC2 {
+				if err := addStartupC2Script(exp, node, startupFile, startupC2Windows); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -314,25 +519,6 @@ func (Startup) PostStart(ctx context.Context, exp *types.Experiment) error {
 	for _, node := range exp.Spec.Topology().Nodes() {
 		if node.External() {
 			continue
-		}
-
-		// Windows 10 doesn't automatically run scripts in the startup folder;
-		// only re-run it here if default apps (which set up that script) are
-		// enabled for this node.
-		if defaultAppsEnabled(node) && strings.EqualFold(node.Hardware().OSType(), "windows") {
-			if ver, ok := node.GetAnnotation("windows-version"); ok && (ver == "10" || ver == 10) {
-				_, err := mm.ExecC2Command(
-					mm.C2NS(exp.Metadata.Name),
-					mm.C2VM(node.General().Hostname()),
-					mm.C2SkipActiveClientCheck(true),
-					mm.C2Command(
-						`powershell.exe -noprofile -executionpolicy bypass -file /phenix/phenix-startup.ps1`,
-					),
-				)
-				if err != nil {
-					return fmt.Errorf("execute C2 command to run Windows startup script: %w", err)
-				}
-			}
 		}
 
 		// The autotunnel annotation is independent of default apps, so it is

--- a/src/go/app/startup_test.go
+++ b/src/go/app/startup_test.go
@@ -1,0 +1,391 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+
+	"phenix/store"
+	"phenix/types"
+	v1 "phenix/types/version/v1"
+	v2 "phenix/types/version/v2"
+)
+
+func TestStartupPreStartC2TriggerMatrix(t *testing.T) {
+	tests := []struct {
+		name             string
+		annotations      map[string]any
+		snapshot         bool
+		injectPartition  int
+		wantCommands     bool
+		wantStartupInj   bool
+		wantStagedScript bool
+	}{
+		{
+			name:             "annotation enabled on injectable node",
+			annotations:      map[string]any{startupViaCCAnnotation: true},
+			snapshot:         true,
+			injectPartition:  1,
+			wantCommands:     true,
+			wantStartupInj:   false,
+			wantStagedScript: true,
+		},
+		{
+			name:             "inject partition zero",
+			snapshot:         true,
+			injectPartition:  0,
+			wantCommands:     true,
+			wantStartupInj:   true,
+			wantStagedScript: true,
+		},
+		{
+			name:            "snapshot false without annotation",
+			snapshot:        false,
+			injectPartition: 1,
+			wantCommands:    false,
+			wantStartupInj:  true,
+		},
+		{
+			name:            "normal injectable node",
+			snapshot:        true,
+			injectPartition: 1,
+			wantCommands:    false,
+			wantStartupInj:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := newStartupTestNode(t, "linux1", osLinux, tt.snapshot, tt.injectPartition)
+			node.AnnotationsF = tt.annotations
+
+			exp, mmDir := newStartupTestExperiment(t, node, nil)
+			runStartupPreStart(t, exp, mmDir)
+
+			wantCommands := []string{
+				"send exp1/linux1-hostname.sh",
+				"exec-once bash /tmp/miniccc/files/exp1/linux1-hostname.sh",
+				"send exp1/linux1-timezone.sh",
+				"exec-once bash /tmp/miniccc/files/exp1/linux1-timezone.sh",
+				"send exp1/linux1-interfaces.sh",
+				"exec-once bash /tmp/miniccc/files/exp1/linux1-interfaces.sh",
+			}
+
+			for _, command := range wantCommands {
+				if got := hasCommand(node, command); got != tt.wantCommands {
+					t.Fatalf("command %q present = %v, want %v", command, got, tt.wantCommands)
+				}
+			}
+
+			for _, dst := range []string{linuxHostnameInjectDst, linuxTimezoneInjectDst, linuxIfaceInjectDst} {
+				if got := hasInjection(node, dst); got != tt.wantStartupInj {
+					t.Fatalf("injection %q present = %v, want %v", dst, got, tt.wantStartupInj)
+				}
+			}
+
+			staged := filepath.Join(mmDir, "exp1", "linux1-hostname.sh")
+			_, err := os.Stat(staged)
+			if tt.wantStagedScript && err != nil {
+				t.Fatalf("expected staged script %s: %v", staged, err)
+			}
+			if !tt.wantStagedScript && !os.IsNotExist(err) {
+				t.Fatalf("unexpected staged script %s", staged)
+			}
+		})
+	}
+}
+
+func TestStartupPreStartWindowsC2Commands(t *testing.T) {
+	node := newStartupTestNode(t, "win1", osWindows, true, 0)
+	exp, mmDir := newStartupTestExperiment(t, node, nil)
+
+	runStartupPreStart(t, exp, mmDir)
+
+	wantSend := "send exp1/win1-startup.ps1"
+	wantExec := "exec-once cmd /c 'powershell.exe -noprofile -executionpolicy bypass -file /tmp/miniccc/files/exp1/win1-startup.ps1'"
+
+	if !hasCommand(node, wantSend) {
+		t.Fatalf("missing command %q", wantSend)
+	}
+	if !hasCommand(node, wantExec) {
+		t.Fatalf("missing command %q", wantExec)
+	}
+	if !hasInjection(node, windowsStartupInjectDst) {
+		t.Fatalf("expected Windows startup script injection to remain for inject partition 0")
+	}
+	if hasInjection(node, legacyWindowsStartupWrapperDst) {
+		t.Fatalf("unexpected Windows startup wrapper injection")
+	}
+	if hasInjection(node, windowsSchedulerDst) || hasInjection(node, "/"+windowsSchedulerDst) {
+		t.Fatalf("unexpected Windows Start Menu scheduler injection")
+	}
+
+	staged := filepath.Join(mmDir, "exp1", "win1-startup.ps1")
+	if _, err := os.Stat(staged); err != nil {
+		t.Fatalf("expected staged Windows script %s: %v", staged, err)
+	}
+}
+
+func TestStartupPreStartAnnotationPreservesUnrelatedInjections(t *testing.T) {
+	node := newStartupTestNode(t, "linux1", osLinux, true, 1)
+	node.AnnotationsF = map[string]any{startupViaCCAnnotation: true}
+	node.InjectionsF = []*v1.Injection{
+		{SrcF: "user-file", DstF: "/etc/user-file"},
+		{SrcF: "old-hostname", DstF: linuxHostnameInjectDst},
+		{SrcF: "old-wrapper", DstF: legacyWindowsStartupWrapperDst},
+		{SrcF: "old-scheduler", DstF: windowsSchedulerDst},
+	}
+
+	exp, mmDir := newStartupTestExperiment(t, node, nil)
+	runStartupPreStart(t, exp, mmDir)
+
+	if !hasInjection(node, "/etc/user-file") {
+		t.Fatalf("expected unrelated user injection to remain")
+	}
+	if hasInjection(node, linuxHostnameInjectDst) {
+		t.Fatalf("unexpected startup app injection")
+	}
+	if hasInjection(node, legacyWindowsStartupWrapperDst) {
+		t.Fatalf("unexpected stale Windows startup wrapper injection")
+	}
+	if hasInjection(node, windowsSchedulerDst) {
+		t.Fatalf("unexpected stale scheduler injection")
+	}
+	if !hasCommand(node, "send exp1/linux1-hostname.sh") {
+		t.Fatalf("expected startup C2 send command")
+	}
+}
+
+func TestStartupPreStartRemovesLegacyWindowsStartupInjectionsWithoutAnnotation(t *testing.T) {
+	node := newStartupTestNode(t, "win1", osWindows, true, 1)
+	node.InjectionsF = []*v1.Injection{
+		{SrcF: "user-file", DstF: "/etc/user-file"},
+		{SrcF: "old-wrapper", DstF: legacyWindowsStartupWrapperDst},
+		{SrcF: "old-scheduler", DstF: windowsSchedulerDst},
+		{SrcF: "old-scheduler-abs", DstF: "/" + windowsSchedulerDst},
+	}
+
+	exp, mmDir := newStartupTestExperiment(t, node, nil)
+	runStartupPreStart(t, exp, mmDir)
+
+	if !hasInjection(node, "/etc/user-file") {
+		t.Fatalf("expected unrelated user injection to remain")
+	}
+	if !hasInjection(node, windowsStartupInjectDst) {
+		t.Fatalf("expected current Windows startup injection to remain")
+	}
+	if hasInjection(node, legacyWindowsStartupWrapperDst) {
+		t.Fatalf("unexpected stale Windows startup wrapper injection")
+	}
+	if hasInjection(node, windowsSchedulerDst) || hasInjection(node, "/"+windowsSchedulerDst) {
+		t.Fatalf("unexpected stale Windows Start Menu scheduler injection")
+	}
+	if hasCommand(node, "send exp1/win1-startup.ps1") {
+		t.Fatalf("unexpected startup C2 command")
+	}
+}
+
+func TestStartupPreStartC2CommandsAreIdempotent(t *testing.T) {
+	node := newStartupTestNode(t, "linux1", osLinux, true, 0)
+	exp, mmDir := newStartupTestExperiment(t, node, nil)
+
+	runStartupPreStart(t, exp, mmDir)
+	first := append([]string(nil), node.CommandsF...)
+
+	runStartupPreStart(t, exp, mmDir)
+	second := append([]string(nil), node.CommandsF...)
+
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("commands changed after second PreStart:\nfirst:  %#v\nsecond: %#v", first, second)
+	}
+	if len(second) != 6 {
+		t.Fatalf("expected 6 startup C2 commands, got %d: %#v", len(second), second)
+	}
+}
+
+func TestStartupPreStartRemovesStaleC2Commands(t *testing.T) {
+	node := newStartupTestNode(t, "linux1", osLinux, true, 1)
+	node.CommandsF = []string{
+		"send exp1/linux1-hostname.sh",
+		"exec-once bash /tmp/miniccc/files/exp1/linux1-hostname.sh",
+		"exec df -h",
+	}
+
+	exp, mmDir := newStartupTestExperiment(t, node, nil)
+	runStartupPreStart(t, exp, mmDir)
+
+	if hasCommand(node, "send exp1/linux1-hostname.sh") {
+		t.Fatalf("unexpected stale startup C2 send command")
+	}
+	if hasCommand(node, "exec-once bash /tmp/miniccc/files/exp1/linux1-hostname.sh") {
+		t.Fatalf("unexpected stale startup C2 exec command")
+	}
+	if !hasCommand(node, "exec df -h") {
+		t.Fatalf("expected user command to remain")
+	}
+}
+
+func TestStartupViaCCAnnotationValues(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want bool
+	}{
+		{name: "bool true", val: true, want: true},
+		{name: "bool false", val: false, want: false},
+		{name: "string true", val: "true", want: true},
+		{name: "string false", val: "false", want: false},
+		{name: "string zero", val: "0", want: false},
+		{name: "int zero", val: 0, want: false},
+		{name: "int one", val: 1, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := newStartupTestNode(t, "linux1", osLinux, true, 1)
+			node.AnnotationsF = map[string]any{startupViaCCAnnotation: tt.val}
+
+			if got := startupViaCCEnabled(node); got != tt.want {
+				t.Fatalf("startupViaCCEnabled = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartupPreStartLinuxDomainScriptUsesC2(t *testing.T) {
+	node := newStartupTestNode(t, "linux1", osLinux, true, 0)
+	scenario := &v2.ScenarioSpec{AppsF: []*v2.ScenarioApp{
+		{
+			NameF: "startup",
+			HostsF: []*v2.ScenarioAppHost{
+				{
+					HostnameF: "linux1",
+					MetadataF: map[string]any{
+						"domain_controller": map[string]any{
+							"username": "admin",
+							"password": "password",
+							"domain":   "example.test",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	exp, mmDir := newStartupTestExperiment(t, node, scenario)
+	runStartupPreStart(t, exp, mmDir)
+
+	if !hasCommand(node, "send exp1/linux1-domain.sh") {
+		t.Fatalf("expected domain script send command")
+	}
+	if !hasCommand(node, "exec-once bash /tmp/miniccc/files/exp1/linux1-domain.sh") {
+		t.Fatalf("expected domain script exec command")
+	}
+	if _, err := os.Stat(filepath.Join(mmDir, "exp1", "linux1-domain.sh")); err != nil {
+		t.Fatalf("expected staged domain script: %v", err)
+	}
+}
+
+// newStartupTestNode builds a minimal VM node with a real test disk path.
+func newStartupTestNode(t *testing.T, hostname, osType string, snapshot bool, injectPartition int) *v1.Node {
+	t.Helper()
+
+	image := filepath.Join(t.TempDir(), hostname+".qc2")
+	if err := os.WriteFile(image, []byte("disk"), 0o600); err != nil {
+		t.Fatalf("creating test image: %v", err)
+	}
+
+	return &v1.Node{
+		TypeF: "VirtualMachine",
+		GeneralF: &v1.General{
+			HostnameF:  hostname,
+			SnapshotF:  &snapshot,
+			DoNotBootF: boolPtr(false),
+		},
+		HardwareF: &v1.Hardware{
+			OSTypeF: osType,
+			DrivesF: []*v1.Drive{
+				{
+					ImageF:           image,
+					InjectPartitionF: &injectPartition,
+				},
+			},
+		},
+		NetworkF: &v1.Network{},
+	}
+}
+
+// newStartupTestExperiment builds a minimal experiment and redirects minimega file staging.
+func newStartupTestExperiment(t *testing.T, node *v1.Node, scenario *v2.ScenarioSpec) (*types.Experiment, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	mmDir := filepath.Join(root, "images")
+
+	oldStartupMMFullPath := startupMMFullPath
+	startupMMFullPath = func(rel string) string {
+		return filepath.Join(mmDir, filepath.FromSlash(rel))
+	}
+
+	t.Cleanup(func() {
+		startupMMFullPath = oldStartupMMFullPath
+	})
+
+	spec := &v1.ExperimentSpec{
+		ExperimentNameF: "exp1",
+		BaseDirF:        filepath.Join(root, "experiments", "exp1"),
+		TopologyF:       &v1.TopologySpec{NodesF: []*v1.Node{node}},
+		ScenarioF:       scenario,
+	}
+	if err := spec.Init(); err != nil {
+		t.Fatalf("initializing test experiment spec: %v", err)
+	}
+
+	status := &v1.ExperimentStatus{}
+	if err := status.Init(); err != nil {
+		t.Fatalf("initializing test experiment status: %v", err)
+	}
+
+	return &types.Experiment{
+		Metadata: store.ConfigMetadata{Name: "exp1"},
+		Spec:     spec,
+		Status:   status,
+	}, mmDir
+}
+
+// runStartupPreStart creates the staged file directory and invokes startup PreStart.
+func runStartupPreStart(t *testing.T, exp *types.Experiment, mmDir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(mmDir, 0o750); err != nil {
+		t.Fatalf("creating minimega file directory: %v", err)
+	}
+
+	if err := (Startup{}).PreStart(context.Background(), exp); err != nil {
+		t.Fatalf("running startup PreStart: %v", err)
+	}
+}
+
+// hasCommand reports whether the node contains command.
+func hasCommand(node *v1.Node, command string) bool {
+	return slices.Contains(node.CommandsF, command)
+}
+
+// hasInjection reports whether the node contains an injection targeting dst.
+func hasInjection(node *v1.Node, dst string) bool {
+	for _, injection := range node.InjectionsF {
+		if injection.DstF == dst {
+			return true
+		}
+	}
+
+	return false
+}
+
+// boolPtr returns a pointer to v.
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/src/go/types/version/v1/node.go
+++ b/src/go/types/version/v1/node.go
@@ -323,6 +323,11 @@ func (n *Node) AddCommand(cmd string) {
 	n.CommandsF = append(n.CommandsF, cmd)
 }
 
+// SetCommands replaces the node command list.
+func (n *Node) SetCommands(commands []string) {
+	n.CommandsF = commands
+}
+
 func (n Node) GetAnnotation(a string) (any, bool) {
 	if n.AnnotationsF == nil {
 		return nil, false


### PR DESCRIPTION
# feat (startup): support C2 delivery for startup scripts

## Description

Deliver generated startup app scripts through minimega C2 when disk injection is explicitly bypassed or unavailable for a node.

Use C2 startup delivery in these states:

- phenix/startup-via-cc is enabled: queue C2 send and exec-once commands and suppress only startup-owned injections
- first drive inject_partition is 0: queue C2 send and exec-once commands while leaving startup injections in the spec for existing template behavior
- snapshot is false without the annotation: keep existing behavior and do not automatically switch startup scripts to C2
- normal injectable nodes: keep disk injection and do not add startup C2 commands

Stage C2-delivered scripts under the minimega filepath directory as <experiment>/<script>, then execute them from /tmp/miniccc/files in the guest. Use bash for Linux/RHEL/CentOS scripts and the quoted powershell command form for Windows scripts.

Also remove legacy Windows startup wrapper, Start Menu scheduler, and windows-version handling, with temporary cleanup for stale wrapper/scheduler injections left by older runs.

Tests:
- env GOCACHE=/tmp/go-build-cache go test ./app ./api/experiment ./util/mm

## Related Issue

N/A

## Type of Change

Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

None