### PR TITLE
fix(mm): add additional checks and safety

### DIFF
--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -576,7 +576,7 @@ func Start(ctx context.Context, opts ...StartOption) error {
 			return fmt.Errorf("deleting experiment snapshots and CC responses: %w", err)
 		}
 
-		err = mm.ReadScriptFromFile(mmScript)
+		err = mm.ReadScriptFromFile(exp.Spec.ExperimentName(), mmScript)
 		if err != nil {
 			if !o.mmErrAsWarn {
 				_ = mm.ClearNamespace(exp.Spec.ExperimentName())
@@ -734,7 +734,7 @@ func Start(ctx context.Context, opts ...StartOption) error {
 	if o.errChan == nil {
 		if !o.dryrun {
 			if exp.Spec.Topology().HasCommands() {
-				err = mm.ReadScriptFromFile(ccScript)
+				err = mm.ReadScriptFromFile(exp.Spec.ExperimentName(), ccScript)
 				if err != nil {
 					errors := multierror.Append(
 						nil,
@@ -799,7 +799,7 @@ func Start(ctx context.Context, opts ...StartOption) error {
 
 			if !o.dryrun {
 				if exp.Spec.Topology().HasCommands() {
-					err = mm.ReadScriptFromFile(ccScript)
+					err = mm.ReadScriptFromFile(exp.Spec.ExperimentName(), ccScript)
 					if err != nil {
 						o.errChan <- fmt.Errorf("reading minimega cc script: %w", err)
 

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -119,7 +119,7 @@ func (s *SOH) deployCapture(exp *types.Experiment, dryrun bool) error {
 	}
 
 	if !dryrun {
-		err = mm.ReadScriptFromFile(filename)
+		err = mm.ReadScriptFromFile(exp.Spec.ExperimentName(), filename)
 		if err != nil {
 			return fmt.Errorf("reading packet capture script: %w", err)
 		}

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hpcloud/tail v1.0.0
 	github.com/json-iterator/go v1.1.12
 	github.com/lmittmann/tint v1.0.4

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -157,8 +157,9 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/src/go/tmpl/templates/minimega_script.tmpl
+++ b/src/go/tmpl/templates/minimega_script.tmpl
@@ -1,4 +1,3 @@
-namespace {{ .ExperimentName }}
 ns queueing true
 
 {{- if and (ne .VLANs.Min 0) (ne .VLANs.Max 0) }}

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -30,8 +30,9 @@ var (
 	ErrScreenshotNotFound = errors.New("screenshot not found")
 )
 
-const vmInfoCmd = "vm info"
 const (
+	vmInfoCmd = "vm info"
+
 	c2ActiveCheckInterval  = 2 * time.Second
 	responseWaitInterval   = 1 * time.Second
 	responseRegexGroupUUID = 2
@@ -43,13 +44,23 @@ const (
 // instances of the Minimega struct.
 var ccMu sync.Mutex //nolint:gochecknoglobals // global lock
 
+// Cache of the last known good headnode name. The headnode does not change for
+// the life of the process.
+var headnode struct { //nolint:gochecknoglobals // process-lifetime cache
+	mu   sync.Mutex
+	name string
+}
+
 // Regular express to use for matching C2 response headers.
 var responseRegex = regexp.MustCompile(`(\d*)\/(.*)\/(stdout|stderr):`)
 
 type Minimega struct{}
 
-func (Minimega) ReadScriptFromFile(filename string) error {
-	cmd := mmcli.NewCommand()
+// ReadScriptFromFile runs `read` against ns. The namespace has to travel
+// with the command: minimega's `read` prefixes every line of the script
+// with the namespace that was active when it started.
+func (Minimega) ReadScriptFromFile(ns, filename string) error {
+	cmd := mmcli.NewNamespacedCommand(ns)
 	cmd.Command = "read " + filename
 
 	err := mmcli.ErrorResponse(mmcli.Run(cmd))
@@ -278,15 +289,21 @@ func (Minimega) GetVMScreenshot(opts ...Option) ([]byte, error) {
 	cmd := mmcli.NewNamespacedCommand(o.ns)
 	cmd.Command = fmt.Sprintf("vm screenshot %s file /dev/null %s", o.vm, o.screenshotSize)
 
+	var (
+		screenshot []byte
+		err        error
+	)
+
+	// Drain the full response channel
 	for resps := range mmcli.Run(cmd) {
 		for _, resp := range resps.Resp {
-			if resp.Error != "" {
-				if strings.HasPrefix(resp.Error, "vm not found:") {
-					return nil, ErrVMNotFound
-				}
+			if screenshot != nil {
+				continue
+			}
 
-				if strings.HasPrefix(resp.Error, "vm not running:") {
-					return nil, ErrVMNotFound
+			if resp.Error != "" {
+				if strings.HasPrefix(resp.Error, "vm not found:") || strings.HasPrefix(resp.Error, "vm not running:") {
+					err = ErrVMNotFound
 				}
 
 				continue
@@ -297,13 +314,24 @@ func (Minimega) GetVMScreenshot(opts ...Option) ([]byte, error) {
 			}
 
 			data, _ := resp.Data.(string)
-			screenshot, err := base64.StdEncoding.DecodeString(data)
-			if err != nil {
-				return nil, fmt.Errorf("decoding screenshot: %w", err)
+
+			decoded, decErr := base64.StdEncoding.DecodeString(data)
+			if decErr != nil {
+				err = fmt.Errorf("decoding screenshot: %w", decErr)
+				continue
 			}
 
-			return screenshot, nil
+			screenshot = decoded
 		}
+	}
+
+	// A screenshot found on any host wins over any error recorded from another
+	if screenshot != nil {
+		return screenshot, nil
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, ErrScreenshotNotFound
@@ -928,14 +956,22 @@ func (Minimega) Headnode() string {
 	hosts := processNamespaceHosts("minimega")
 
 	if len(hosts) == 0 {
-		return "" // ???
-	}
+		// hosts is empty on any mmcli failure, fall back to the last known headnode
+		headnode.mu.Lock()
+		defer headnode.mu.Unlock()
 
-	headnode := hosts[0].Name
+		return headnode.name
+	}
 
 	// Trim host name suffixes (like -minimega, or -phenix) potentially added to
 	// Docker containers by Docker Compose config.
-	return common.TrimHostnameSuffixes(headnode)
+	name := common.TrimHostnameSuffixes(hosts[0].Name)
+
+	headnode.mu.Lock()
+	headnode.name = name
+	headnode.mu.Unlock()
+
+	return name
 }
 
 func (m Minimega) IsHeadnode(node string) bool {
@@ -943,28 +979,13 @@ func (m Minimega) IsHeadnode(node string) bool {
 	// Docker containers by Docker Compose config.
 	node = common.TrimHostnameSuffixes(node)
 
-	head := m.Headnode()
-
-	// If we can't determine the headnode, assume the local node
-	if head == "" {
-		plog.Warn(
-			plog.TypeSystem,
-			"headnode unknown; assuming local to avoid mesh-send-to-self",
-			"node", node,
-		)
-
-		return true
-	}
-
-	if node == head {
+	if node == m.Headnode() {
 		return true
 	}
 
 	// Fall back to the local hostname
 	if local, err := os.Hostname(); err == nil {
-		if node == common.TrimHostnameSuffixes(local) {
-			return true
-		}
+		return node == common.TrimHostnameSuffixes(local)
 	}
 
 	return false
@@ -1007,16 +1028,45 @@ func (Minimega) GetVLANs(opts ...Option) (map[string]int, error) {
 	return vlans, nil
 }
 
-func (Minimega) IsC2ClientActive(opts ...C2Option) error {
-	o := NewC2Options(opts...)
+func (m Minimega) IsC2ClientActive(opts ...C2Option) error {
+	_, _, err := m.c2Client(NewC2Options(opts...))
+
+	return err
+}
+
+// pickVM returns the VM named exactly `name`, else the first match. The lookup
+// folds case, so a namespace holding two names differing only in case would
+// otherwise be able to resolve to the wrong VM.
+func pickVM(vms VMs, name string) VM {
+	for _, vm := range vms {
+		if vm.Name == name {
+			return vm
+		}
+	}
+
+	// If exact match not found, return the first match.
+	return vms[0]
+}
+
+// c2Client waits for a VM's miniccc client to register and returns the name
+// minimega launched the VM under along with its UUID. Callers must address the
+// VM by one of those: this lookup folds case (minicli's `.filter` lowercases
+// both sides) while `cc filter name=`, `cc mount` and `clear cc mount` match
+// exactly, so a mis-cased name passes the check here and then targets zero
+// clients. The UUID is immune to that and is preferred where minimega accepts
+// one.
+func (Minimega) c2Client(o c2Options) (string, string, error) {
 	if o.skipActiveClientCheck {
-		return nil
+		return o.vm, "", nil
 	}
 
 	vms := GetVMInfo(NS(o.ns), VMName(o.vm))
 	if len(vms) == 0 {
-		return fmt.Errorf("vm %s does not exist", o.vm)
+		return "", "", fmt.Errorf("vm %s does not exist", o.vm)
 	}
+
+	// Try to find exact name match
+	vm := pickVM(vms, o.vm)
 
 	cmd := mmcli.NewNamespacedCommand(o.ns)
 	cmd.Command = "cc client"
@@ -1026,7 +1076,7 @@ func (Minimega) IsC2ClientActive(opts ...C2Option) error {
 		// the actual hostname of the VM as reported by the miniccc agent, which may
 		// not always match the name minimega uses to track the VM.
 		cmd.Columns = []string{"uuid"}
-		cmd.Filters = []string{"uuid=" + vms[0].UUID}
+		cmd.Filters = []string{"uuid=" + vm.UUID}
 	} else {
 		// Even though `cc clients` returns the actual hostname of the VM as reported
 		// by the miniccc agent, we still go ahead and check for the VM name as
@@ -1034,7 +1084,7 @@ func (Minimega) IsC2ClientActive(opts ...C2Option) error {
 		// (per the startup app). This way, we don't consider Windows VMs ready until
 		// they've rebooted to get their hostname set correctly.
 		cmd.Columns = []string{"hostname"}
-		cmd.Filters = []string{"hostname=" + vms[0].Name}
+		cmd.Filters = []string{"hostname=" + vm.Name}
 	}
 
 	after := time.After(o.timeout)
@@ -1042,14 +1092,14 @@ func (Minimega) IsC2ClientActive(opts ...C2Option) error {
 	for {
 		select {
 		case <-o.ctx.Done():
-			return o.ctx.Err()
+			return "", "", o.ctx.Err()
 		case <-after:
-			return ErrC2ClientNotActive
+			return "", "", ErrC2ClientNotActive
 		default:
 			rows := mmcli.RunTabular(cmd)
 
 			if len(rows) != 0 {
-				return nil
+				return vm.Name, vm.UUID, nil
 			}
 
 			time.Sleep(c2ActiveCheckInterval)
@@ -1058,19 +1108,30 @@ func (Minimega) IsC2ClientActive(opts ...C2Option) error {
 }
 
 func (m Minimega) ExecC2Command(opts ...C2Option) (string, error) { //nolint:funlen // complex logic
-	err := m.IsC2ClientActive(opts...)
+	o := NewC2Options(opts...)
+
+	// Address the VM below by the name minimega launched it under, not by
+	// whatever the caller spelled: `cc filter name=`, `cc mount` and
+	// `clear cc mount` all match it exactly.
+	vmName, vmUUID, err := m.c2Client(o)
 	if err != nil {
 		return "", fmt.Errorf("cannot execute command: %w", err)
 	}
-
-	o := NewC2Options(opts...)
 
 	exec := func(ns, vm, cmd string) (string, error) {
 		ccMu.Lock()
 		defer ccMu.Unlock()
 
 		c := mmcli.NewNamespacedCommand(ns)
-		c.Command = "cc filter name=" + vm
+
+		// Filter by UUID where we have one. `cc filter name=` falls through to
+		// an implicit tag filter matched against the VM name with a plain
+		// string compare
+		if vmUUID != "" {
+			c.Command = "cc filter uuid=" + vmUUID
+		} else {
+			c.Command = "cc filter name=" + vm
+		}
 
 		if err := mmcli.ErrorResponse(mmcli.Run(c)); err != nil {
 			return "", fmt.Errorf("setting host filter to %s: %w", vm, err)
@@ -1094,7 +1155,7 @@ func (m Minimega) ExecC2Command(opts ...C2Option) (string, error) { //nolint:fun
 	if o.testConn != "" {
 		cmd := "cc test-conn " + o.testConn
 
-		id, err := exec(o.ns, o.vm, cmd)
+		id, err := exec(o.ns, vmName, cmd)
 		if err != nil {
 			return "", fmt.Errorf("calling '%s' for vm %s: %w", cmd, o.vm, err)
 		}
@@ -1112,7 +1173,7 @@ func (m Minimega) ExecC2Command(opts ...C2Option) (string, error) { //nolint:fun
 	if o.sendFile != "" {
 		cmd := "cc send " + o.sendFile
 
-		id, err := exec(o.ns, o.vm, cmd)
+		id, err := exec(o.ns, vmName, cmd)
 		if err != nil {
 			return "", fmt.Errorf("sending file '%s' to vm %s: %w", o.sendFile, o.vm, err)
 		}
@@ -1135,7 +1196,7 @@ func (m Minimega) ExecC2Command(opts ...C2Option) (string, error) { //nolint:fun
 	if o.command != "" {
 		cmd := "cc exec " + o.command
 
-		id, err := exec(o.ns, o.vm, cmd)
+		id, err := exec(o.ns, vmName, cmd)
 		if err != nil {
 			return "", fmt.Errorf("calling '%s' for vm %s: %w", cmd, o.vm, err)
 		}
@@ -1154,23 +1215,23 @@ func (m Minimega) ExecC2Command(opts ...C2Option) (string, error) { //nolint:fun
 		if *o.mount {
 			var (
 				path = GetLocalMountPath(o.ns, o.vm)
-				cmd  = fmt.Sprintf("cc mount %s %s", o.vm, path)
+				cmd  = fmt.Sprintf("cc mount %s %s", vmName, path)
 			)
 
 			if err := os.MkdirAll(path, 0o750); err != nil {
 				return "", fmt.Errorf("creating mount directory: %w", err)
 			}
 
-			id, err := exec(o.ns, o.vm, cmd)
+			id, err := exec(o.ns, vmName, cmd)
 			if err != nil {
 				return "", fmt.Errorf("error creating mount: %w", err)
 			}
 
 			return id, nil
 		} else {
-			cmd := "clear cc mount " + o.vm
+			cmd := "clear cc mount " + vmName
 
-			id, err := exec(o.ns, o.vm, cmd)
+			id, err := exec(o.ns, vmName, cmd)
 			if err != nil {
 				return "", fmt.Errorf("error clearing mount: %w", err)
 			}
@@ -1445,19 +1506,33 @@ func (Minimega) MeshShellResponse(host, command string) (string, error) {
 		cmd.Command = fmt.Sprintf("mesh send %s shell %s", host, command)
 	}
 
+	var (
+		out   string
+		found bool
+	)
+
+	// Drain the full response channel -- returning early would abandon it and wedge the shared minimega connection.
 	for resps := range mmcli.Run(cmd) {
 		for _, resp := range resps.Resp {
 			if resp.Error != "" {
-				plog.Warn(plog.TypeSystem, "error running shell command: ", "cmd", cmd)
+				plog.Warn(plog.TypeSystem, "error running shell command", "cmd", cmd.Command, "error", resp.Error)
 
 				continue
 			}
 
-			return strings.TrimSpace(resp.Response), nil
+			if found {
+				continue
+			}
+
+			out, found = strings.TrimSpace(resp.Response), true
 		}
 	}
 
-	return "", errors.New("error running MeshShellResponse()")
+	if !found {
+		return "", errors.New("error running MeshShellResponse()")
+	}
+
+	return out, nil
 }
 
 func (Minimega) MeshSend(ns, host, command string) error {

--- a/src/go/util/mm/mm.go
+++ b/src/go/util/mm/mm.go
@@ -3,7 +3,7 @@ package mm
 var DefaultMM MM = new(Minimega) //nolint:gochecknoglobals // default implementation
 
 type MM interface { //nolint:interfacebloat // legacy interface
-	ReadScriptFromFile(string) error
+	ReadScriptFromFile(string, string) error
 	ClearNamespace(string) error
 
 	LaunchVMs(string, ...string) error

--- a/src/go/util/mm/mmcli/client.go
+++ b/src/go/util/mm/mmcli/client.go
@@ -16,18 +16,24 @@ import (
 	"phenix/util/common"
 )
 
-var ErrTimeout = errors.New("timeout running command")
-
 var (
-	mu     sync.Mutex       //nolint:gochecknoglobals // global lock
-	mm     *miniclient.Conn //nolint:gochecknoglobals // global connection
-	mmDead bool             //nolint:gochecknoglobals // flags mm for replacement
+	// ErrTimeout is reported when a command does not return within the requested
+	// time period.
+	ErrTimeout = errors.New("timeout running command")
+
+	// ErrNoResponse is reported when minimega closes a command's response stream
+	// without having sent anything. That means the connection was lost, not that
+	// the command legitimately produced no output.
+	ErrNoResponse = errors.New("no response from minimega (connection lost)")
+	mu            sync.Mutex       //nolint:gochecknoglobals // global lock
+	mm            *miniclient.Conn //nolint:gochecknoglobals // global connection
+	mmDead        bool             //nolint:gochecknoglobals // flags mm for replacement
 )
 
-func wrapErr(err error) chan *miniclient.Response {
-	out := make(chan *miniclient.Response, 1)
-
-	out <- &miniclient.Response{ //nolint:exhaustruct // partial initialization
+// errResponse builds the single response value used to report an error back
+// through a response channel.
+func errResponse(err error) *miniclient.Response {
+	return &miniclient.Response{ //nolint:exhaustruct // partial initialization
 		Resp: minicli.Responses{
 			&minicli.Response{ //nolint:exhaustruct // partial initialization
 				Error: err.Error(),
@@ -35,6 +41,29 @@ func wrapErr(err error) chan *miniclient.Response {
 		},
 		More: false,
 	}
+}
+
+// reconstructErr turns a response's error string back into an error, restoring
+// the sentinel identity where the string is one of ours.
+func reconstructErr(msg string) error {
+	for _, sentinel := range []error{ErrTimeout, ErrNoResponse} {
+		if msg == sentinel.Error() {
+			return sentinel
+		}
+
+		// streamEnded wraps its sentinel with context before it is flattened to a string
+		if suffix := ": " + sentinel.Error(); strings.HasSuffix(msg, suffix) {
+			return fmt.Errorf("%s: %w", strings.TrimSuffix(msg, suffix), sentinel)
+		}
+	}
+
+	return errors.New(msg)
+}
+
+func wrapErr(err error) chan *miniclient.Response {
+	out := make(chan *miniclient.Response, 1)
+
+	out <- errResponse(err)
 
 	close(out)
 
@@ -50,7 +79,7 @@ func ErrorResponse(responses chan *miniclient.Response) error {
 	for response := range responses {
 		for _, resp := range response.Resp {
 			if resp.Error != "" {
-				errs = multierror.Append(errs, errors.New(resp.Error))
+				errs = multierror.Append(errs, reconstructErr(resp.Error))
 			}
 		}
 	}
@@ -76,7 +105,7 @@ func SingleResponse(responses chan *miniclient.Response) (string, error) {
 
 		for _, r := range response.Resp {
 			if r.Error != "" {
-				err = errors.New(r.Error)
+				err = reconstructErr(r.Error)
 
 				continue
 			}
@@ -118,7 +147,7 @@ func SingleDataResponse(responses chan *miniclient.Response) (any, error) {
 
 		for _, r := range response.Resp {
 			if r.Error != "" {
-				err = errors.New(r.Error)
+				err = reconstructErr(r.Error)
 
 				continue
 			}
@@ -140,6 +169,12 @@ func SingleDataResponse(responses chan *miniclient.Response) (any, error) {
 // conn returns a usable connection to minimega, dialing or redialing as needed.
 // The caller must hold mu.
 func conn() (*miniclient.Conn, error) {
+	// miniclient records only the FIRST error it encounters and never clears it,
+	// so any non-nil error means this connection is permanently unusable
+	if mm != nil && mm.Error() != nil {
+		mmDead = true
+	}
+
 	if mm == nil || mmDead {
 		c, err := miniclient.Dial(common.MinimegaBase)
 		if err != nil {
@@ -147,22 +182,6 @@ func conn() (*miniclient.Conn, error) {
 		}
 
 		mm, mmDead = c, false
-	}
-
-	// If the connection is already in a broken state, redial.
-	if err := mm.Error(); err != nil {
-		s := err.Error()
-
-		if strings.Contains(s, "broken pipe") || strings.Contains(s, "no such file or directory") {
-			c, err := miniclient.Dial(common.MinimegaBase)
-			if err != nil {
-				return nil, fmt.Errorf("unable to redial: %w", err)
-			}
-
-			mm, mmDead = c, false
-		} else {
-			return nil, fmt.Errorf("minimega error: %w", err)
-		}
 	}
 
 	return mm, nil
@@ -180,10 +199,77 @@ func markDead(c *miniclient.Conn) {
 	}
 }
 
-// Run dials the minimega Unix socket and runs the given command, automatically
-// redialing if disconnected. Any errors encountered will be returned as part of
-// the response channel.
+// streamEnded reports the error, if any, that should be appended once a response
+// stream has closed. miniclient signals a lost connection only through its own
+// private error field and closes the response channel having sent nothing.
+func streamEnded(c *miniclient.Conn, count int) error {
+	err := c.Error()
+
+	if err == nil {
+		if count > 0 {
+			return nil
+		}
+
+		err = ErrNoResponse
+	}
+
+	return fmt.Errorf("running minimega command: %w", err)
+}
+
+// guard forwards responses from the shared connection, reporting a truncated or
+// empty stream as an error rather than as a successful empty result.
+//
+// release is called once the terminal error has been read, before markDead,
+// which takes mu itself. It must not be called any earlier: miniclient closes
+// the response channel before releasing its own connection lock, so another
+// command could otherwise take that lock and overwrite Conn.err first.
+//
+// Callers MUST drain the returned channel. Abandoning it blocks this goroutine,
+// and miniclient's reader behind it, for the life of the process.
+func guard(
+	c *miniclient.Conn,
+	in chan *miniclient.Response,
+	release func(),
+) chan *miniclient.Response {
+	out := make(chan *miniclient.Response)
+
+	go func() {
+		defer close(out)
+
+		var count int
+
+		for resp := range in {
+			count++
+
+			out <- resp
+		}
+
+		err := streamEnded(c, count)
+
+		release()
+
+		if err == nil {
+			return
+		}
+
+		markDead(c)
+
+		out <- errResponse(err)
+	}()
+
+	return out
+}
+
+// Run runs the given command against minimega, automatically redialing the
+// shared connection if it was disconnected. Any errors encountered will be
+// returned as part of the response channel, which the caller must drain.
 func Run(c *Command) chan *miniclient.Response {
+	cmdStr := c.String()
+
+	if c.Timeout > 0 {
+		return runWithTimeout(cmdStr, c.Timeout)
+	}
+
 	mu.Lock()
 
 	active, err := conn()
@@ -193,38 +279,63 @@ func Run(c *Command) chan *miniclient.Response {
 		return wrapErr(err)
 	}
 
-	// Build the command string and release mu before waiting on the response.
-	// The connection's own internal lock serializes the actual exchange, so we
-	// don't need to (and must not) hold mu across a potentially slow command --
-	// doing so would serialize all minimega traffic behind one slow command.
-	cmdStr := c.String()
+	// mu is held until guard has read the terminal error, so no other command
+	// can reach Conn.err in between
+	return guard(active, active.Run(cmdStr), mu.Unlock)
+}
 
-	mu.Unlock()
-
-	if c.Timeout == 0 {
-		return active.Run(cmdStr)
+// runWithTimeout runs a command on a connection of its own, so that abandoning
+// it on timeout cannot disturb commands in flight on the shared connection.
+//
+// Callers MUST drain the returned channel, as with guard.
+func runWithTimeout(cmdStr string, timeout time.Duration) chan *miniclient.Response {
+	private, err := miniclient.Dial(common.MinimegaBase)
+	if err != nil {
+		return wrapErr(fmt.Errorf("unable to dial: %w", err))
 	}
 
-	var (
-		resp = make(chan chan *miniclient.Response, 1)
-		done = make(chan struct{})
-	)
+	out := make(chan *miniclient.Response)
 
 	go func() {
-		resp <- active.Run(cmdStr)
+		defer close(out)
+		defer func() { _ = private.Close() }()
 
-		close(done)
+		var (
+			in    = private.Run(cmdStr)
+			after = time.After(timeout)
+			count int
+		)
+
+		for {
+			select {
+			case resp, ok := <-in:
+				if !ok {
+					if err := streamEnded(private, count); err != nil {
+						out <- errResponse(err)
+					}
+
+					return
+				}
+
+				count++
+
+				out <- resp
+			case <-after:
+				// Drain in the background so miniclient's reader can exit. It
+				// may be parked on its unbuffered send, where closing the
+				// connection alone would not release it.
+				go func() {
+					for range in {
+						_ = struct{}{}
+					}
+				}()
+
+				out <- errResponse(ErrTimeout)
+
+				return
+			}
+		}
 	}()
 
-	select {
-	case <-done:
-		return <-resp
-	case <-time.After(c.Timeout):
-		// Dispatch is stuck, close it so the goroutine fails
-		active.Close()
-		// Flag it so the next call redials
-		markDead(active)
-
-		return wrapErr(ErrTimeout)
-	}
+	return out
 }

--- a/src/go/util/mm/mmcli/client_test.go
+++ b/src/go/util/mm/mmcli/client_test.go
@@ -1,0 +1,439 @@
+package mmcli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/activeshadow/libminimega/minicli"
+	"github.com/activeshadow/libminimega/miniclient"
+
+	"phenix/util/common"
+)
+
+const (
+	// testTimeout is short enough to keep the suite fast but long enough that a
+	// loaded CI box won't trip it spuriously.
+	testTimeout = 200 * time.Millisecond
+	// maxWait bounds how long a timeout-bearing command may take to return.
+	maxWait = 5 * time.Second
+	// slowReply holds a reply open well past testTimeout so a slow command and a
+	// timing-out command genuinely overlap.
+	slowReply = 4 * testTimeout
+)
+
+// fakeAction selects how the fake minimega answers a command.
+type fakeAction int
+
+const (
+	// actionReply sends the supplied response.
+	actionReply fakeAction = iota
+	// actionHang answers nothing and leaves the connection open, modelling a
+	// command minimega never gets around to answering.
+	actionHang
+	// actionClose drops the connection without answering, modelling a lost
+	// socket or a restarted minimega.
+	actionClose
+)
+
+type fakeHandler func(cmd string) (*miniclient.Response, fakeAction)
+
+// reply is the response a healthy fake minimega sends.
+func reply(body string) *miniclient.Response {
+	return &miniclient.Response{
+		Resp: minicli.Responses{{Host: "fake", Response: body}},
+	}
+}
+
+// newFakeMinimega starts a fake minimega command socket in a temporary
+// directory and returns that directory, suitable for common.MinimegaBase.
+func newFakeMinimega(t *testing.T, handle fakeHandler) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	listener, err := net.Listen("unix", filepath.Join(dir, "minimega"))
+	if err != nil {
+		t.Fatalf("listening on fake minimega socket: %v", err)
+	}
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			// One goroutine per connection: commands carrying a timeout now dial
+			// a connection of their own, so more than one is live at a time.
+			go serveFake(conn, handle)
+		}
+	}()
+
+	return dir
+}
+
+func serveFake(conn net.Conn, handle fakeHandler) {
+	defer func() { _ = conn.Close() }()
+
+	var (
+		dec = json.NewDecoder(conn)
+		enc = json.NewEncoder(conn)
+	)
+
+	for {
+		var req miniclient.Request
+
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+
+		resp, action := handle(req.Command)
+
+		switch action {
+		case actionClose:
+			return
+		case actionHang:
+			continue
+		case actionReply:
+			if err := enc.Encode(resp); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// useFakeMinimega points the package at the given fake socket directory and
+// resets the shared connection, restoring both afterwards.
+func useFakeMinimega(t *testing.T, dir string) {
+	t.Helper()
+
+	prev := common.MinimegaBase
+	common.MinimegaBase = dir //nolint:reassign // test fixture
+
+	reset := func() {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if mm != nil {
+			_ = mm.Close()
+		}
+
+		mm, mmDead = nil, false
+	}
+
+	reset()
+
+	t.Cleanup(func() {
+		reset()
+
+		common.MinimegaBase = prev //nolint:reassign // test fixture
+	})
+}
+
+func TestRunDeliversResponses(t *testing.T) {
+	dir := newFakeMinimega(t, func(string) (*miniclient.Response, fakeAction) {
+		return reply("pong"), actionReply
+	})
+
+	useFakeMinimega(t, dir)
+
+	cmd := NewCommand()
+	cmd.Command = "version"
+
+	got, err := SingleResponse(Run(cmd))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "pong" {
+		t.Fatalf("got %q, want %q", got, "pong")
+	}
+}
+
+// TestRunSurfacesLostConnection is the regression test for a lost connection
+// being reported as a successful empty result. miniclient records the failure
+// only in its own private error field and closes the response channel having
+// sent nothing, which every helper here used to read as success: ErrorResponse
+// returned nil, SingleResponse returned ("", nil), and RunTabular returned an
+// empty slice with nothing logged.
+func TestRunSurfacesLostConnection(t *testing.T) {
+	dir := newFakeMinimega(t, func(string) (*miniclient.Response, fakeAction) {
+		return nil, actionClose
+	})
+
+	useFakeMinimega(t, dir)
+
+	cmd := NewCommand()
+	cmd.Command = "version"
+
+	err := ErrorResponse(Run(cmd))
+	if err == nil {
+		t.Fatal("ErrorResponse returned nil for a lost connection")
+	}
+
+	// ErrorResponse rebuilds errors with errors.New, so the sentinel identity is
+	// not preserved across the channel -- match on the text instead.
+	if !strings.Contains(err.Error(), "no response from minimega") &&
+		!strings.Contains(err.Error(), "server disconnected") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+
+	cmd = NewCommand()
+	cmd.Command = "version"
+
+	if _, err := SingleResponse(Run(cmd)); err == nil {
+		t.Fatal("SingleResponse returned nil error for a lost connection")
+	}
+}
+
+// TestRunRedialsAfterConnectionLoss covers guard marking the connection dead and
+// conn() redialing on any sticky error. A restarted minimega reports "server
+// disconnected", which the old substring list did not match, wedging phenix
+// until the process itself was restarted.
+func TestRunRedialsAfterConnectionLoss(t *testing.T) {
+	dir := newFakeMinimega(t, func(cmd string) (*miniclient.Response, fakeAction) {
+		if strings.Contains(cmd, "break") {
+			return nil, actionClose
+		}
+
+		return reply("ok"), actionReply
+	})
+
+	useFakeMinimega(t, dir)
+
+	broken := NewCommand()
+	broken.Command = "break"
+
+	if err := ErrorResponse(Run(broken)); err == nil {
+		t.Fatal("expected the connection-losing command to report an error")
+	}
+
+	healthy := NewCommand()
+	healthy.Command = "version"
+
+	got, err := SingleResponse(Run(healthy))
+	if err != nil {
+		t.Fatalf("command after a lost connection failed instead of redialing: %v", err)
+	}
+
+	if got != "ok" {
+		t.Fatalf("got %q, want %q", got, "ok")
+	}
+}
+
+func TestRunWithTimeout(t *testing.T) {
+	dir := newFakeMinimega(t, func(string) (*miniclient.Response, fakeAction) {
+		return nil, actionHang
+	})
+
+	useFakeMinimega(t, dir)
+
+	cmd := NewCommand()
+	cmd.Command = "version"
+	cmd.Timeout = testTimeout
+
+	start := time.Now()
+	err := ErrorResponse(Run(cmd))
+	elapsed := time.Since(start)
+
+	// errors.Is, not a substring match: the error crosses the response channel
+	// as a plain string, so callers can only branch on the timeout if the
+	// sentinel identity survives the round trip (see reconstructErr).
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("expected a timeout error, got %v", err)
+	}
+
+	if elapsed > maxWait {
+		t.Fatalf("timeout took %v, want under %v", elapsed, maxWait)
+	}
+}
+
+// TestTimeoutDoesNotDisturbConcurrentCommands locks in the property that made
+// the timeout path worth changing: one command's deadline must not damage
+// another command that is already in flight. The old code Close()d the shared
+// *miniclient.Conn, so a concurrent reader's stream was truncated and came back
+// empty with no error -- which is how a healthy cluster ended up with
+// Headnode() == "" and cluster commands silently running on the wrong node.
+// Timeout-bearing commands now run on a connection of their own.
+//
+// Note this asserts the desired property rather than reproducing the historical
+// failure exactly: the old code also serialized everything through conn(), so no
+// single test discriminates against every past variant. It does catch the
+// obvious naive fix of keeping the shared connection and still closing it.
+func TestTimeoutDoesNotDisturbConcurrentCommands(t *testing.T) {
+	dir := newFakeMinimega(t, func(cmd string) (*miniclient.Response, fakeAction) {
+		switch {
+		case strings.Contains(cmd, "hang"):
+			return nil, actionHang
+		case strings.Contains(cmd, "slow"):
+			// Hold this connection's reply open past the other command's
+			// deadline so the two genuinely overlap.
+			time.Sleep(slowReply)
+
+			return reply("slow-ok"), actionReply
+		}
+
+		return reply("ok"), actionReply
+	})
+
+	useFakeMinimega(t, dir)
+
+	type result struct {
+		body string
+		err  error
+	}
+
+	done := make(chan result, 1)
+
+	go func() {
+		slow := NewCommand()
+		slow.Command = "slow"
+
+		body, err := SingleResponse(Run(slow))
+
+		done <- result{body: body, err: err}
+	}()
+
+	// Let the slow command take the shared connection first.
+	time.Sleep(testTimeout / 2)
+
+	hang := NewCommand()
+	hang.Command = "hang"
+	hang.Timeout = testTimeout
+
+	if err := ErrorResponse(Run(hang)); err == nil {
+		t.Fatal("expected the hung command to time out")
+	}
+
+	got := <-done
+
+	if got.err != nil {
+		t.Fatalf("concurrent command failed because of an unrelated timeout: %v", got.err)
+	}
+
+	if got.body != "slow-ok" {
+		t.Fatalf(
+			"concurrent command got %q, want %q -- its response stream was truncated",
+			got.body, "slow-ok",
+		)
+	}
+}
+
+// TestReconstructErrKeepsSentinelIdentity covers the round trip that made
+// ExecC2Command's `errors.Is(err, ErrTimeout)` branch dead code: errResponse
+// flattens an error to a string, and rebuilding it with [errors.New] produced
+// something that read correctly but matched nothing.
+func TestReconstructErrKeepsSentinelIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  string
+		want error
+	}{
+		{"bare timeout", ErrTimeout.Error(), ErrTimeout},
+		{"bare no-response", ErrNoResponse.Error(), ErrNoResponse},
+		{
+			"wrapped no-response",
+			"running minimega command: " + ErrNoResponse.Error(),
+			ErrNoResponse,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reconstructErr(tc.msg)
+
+			if !errors.Is(got, tc.want) {
+				t.Fatalf("errors.Is(%v, %v) = false, want true", got, tc.want)
+			}
+
+			if got.Error() != tc.msg {
+				t.Fatalf("message = %q, want %q", got.Error(), tc.msg)
+			}
+		})
+	}
+
+	// An unrelated message must stay an opaque error, not be coerced.
+	if err := reconstructErr("vm not found: foo"); errors.Is(err, ErrTimeout) {
+		t.Fatal("unrelated message matched ErrTimeout")
+	}
+}
+
+// TestRunConcurrentCommands covers the serialization around the shared
+// connection. mu is held across the whole exchange and released inside guard,
+// which then calls markDead -- and markDead takes mu itself, so releasing in the
+// wrong order deadlocks every caller.
+func TestRunConcurrentCommands(t *testing.T) {
+	dir := newFakeMinimega(t, func(cmd string) (*miniclient.Response, fakeAction) {
+		return reply(cmd), actionReply
+	})
+
+	useFakeMinimega(t, dir)
+
+	const workers = 8
+
+	var (
+		wg   sync.WaitGroup
+		errs = make(chan error, workers)
+		done = make(chan struct{})
+	)
+
+	for i := range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			cmd := &Command{Command: fmt.Sprintf("cmd-%d", i)}
+
+			// the fake echoes the command it was sent, so a worker seeing
+			// anything else was handed another worker's response
+			want := cmd.String()
+
+			var count int
+
+			for resp := range Run(cmd) {
+				if len(resp.Resp) == 0 {
+					errs <- fmt.Errorf("%s got a response with no rows", want)
+
+					return
+				}
+
+				if got := resp.Resp[0]; got.Response != want || got.Error != "" {
+					errs <- fmt.Errorf("%s got response %q, error %q", want, got.Response, got.Error)
+
+					return
+				}
+
+				count++
+			}
+
+			if count != 1 {
+				errs <- fmt.Errorf("%s got %d responses, want 1", want, count)
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(maxWait):
+		t.Fatal("concurrent commands deadlocked")
+	}
+
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}

--- a/src/go/util/mm/package.go
+++ b/src/go/util/mm/package.go
@@ -1,7 +1,7 @@
 package mm
 
-func ReadScriptFromFile(filename string) error {
-	return DefaultMM.ReadScriptFromFile(filename)
+func ReadScriptFromFile(ns, filename string) error {
+	return DefaultMM.ReadScriptFromFile(ns, filename)
 }
 
 func ClearNamespace(ns string) error {


### PR DESCRIPTION
# fix(mm): add additional checks and safety

## Description
  * Read experiment scripts as `namespace <exp> read <file>`. The bare `namespace <exp>` line set minimega's process-global active namespace and never put it back, so every other client's unprefixed commands landed there. The cc and packet-capture scripts, which carried no namespace line at all, are now scoped too.
  * Give timed-out commands their own connection so a timeout can no longer tear down the shared one and truncate other in-flight commands. The deadline now bounds the whole exchange, not just dispatch.
  * Report a lost connection as an error; every mmcli helper read it as "no results".
  * Redial on any sticky connection error rather than two hardcoded strings. A restarted minimega reports "server disconnected" and wedged phenix until phenix itself was restarted.
  * IsHeadnode no longer calls every node the headnode when the mesh listing is empty, silently dropping the `mesh send <host>` prefix. Headnode() caches the last known good name.
  * Drain response channels in GetVMScreenshot and MeshShellResponse instead of returning early and wedging the connection lock.
  * Address C2 commands by the name minimega launched the VM under, and filter by UUID where known. The liveness check folds case but `cc filter name=` and `cc mount` do not, so a mis-cased name passed the check and then targeted zero clients.
  * Keep sentinel identity on errors crossing a response channel, so `errors.Is(err, ErrTimeout)` can be true. Requires go-multierror 1.1.1.
  * First tests for mmcli, driven by a fake minimega socket.

## Related Issue
Follow-up to #313 / [sceptre-phenix-apps#110](https://github.com/sandialabs/sceptre-phenix-apps/pull/110).
Pairs with [sceptre-phenix-apps#122](https://github.com/sandialabs/sceptre-phenix-apps/pull/122).
Pairs with [sandia-minimega/minimega#1618](https://github.com/sandia-minimega/minimega/pull/1618)

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
AI-generated. Human reviewed and tested.

