### PR TITLE
fix(mm): replace deprecated migrate commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,4 +55,5 @@ All notable changes to this project will be documented in this file.
 - **Legacy Tests**: Removed outdated `testing/` directory and unused `*_test.go` files (replaced by `examples/`).
 
 ### Fixed
+- **VM Snapshots**: Replaced deprecated minimega `vm migrate` commands with `vm save` and `vm config state` for snapshot, restore, and redeploy workflows.
 - **Timestamp Consistency**: Enforced `2006-01-02 15:04:05.000` time format across file logs.

--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -818,19 +818,19 @@ func Snapshot(expName, vmName, out string, cb func(string)) error { //nolint:fun
 
 	host := status[0]["host"]
 
-	// ***** BEGIN: MIGRATE VM *****
+	// ***** BEGIN: SAVE VM *****
 
-	cmd.Command = fmt.Sprintf("vm migrate %s %s", vmName, out)
+	cmd.Command = fmt.Sprintf("vm save %s %s", vmName, out)
 
 	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
 		return fmt.Errorf("starting memory snapshot for VM %s: %w", vmName, err)
 	}
 
-	cmd.Command = "vm migrate"
+	cmd.Command = "vm save"
 	cmd.Columns = []string{"name", "status", "complete (%)"}
 	cmd.Filters = []string{"name=" + vmName}
 
-	// Adding a 1 second delay before calling "vm migrate"
+	// Adding a 1 second delay before calling "vm save"
 	// for a status update appears to prevent the status call
 	// from crashing minimega
 	time.Sleep(1 * time.Second)
@@ -854,7 +854,7 @@ func Snapshot(expName, vmName, out string, cb func(string)) error { //nolint:fun
 		time.Sleep(1 * time.Second)
 	}
 
-	// ***** END: MIGRATE VM *****
+	// ***** END: SAVE VM *****
 
 	cmd.Command = "vm start " + vmName
 
@@ -948,9 +948,9 @@ func Restore(expName, vmName, snap string) error {
 		return fmt.Errorf("setting uuid for VM %s: %w", vmName, err)
 	}
 
-	cmd.Command = fmt.Sprintf("vm config migrate %s.state", snap)
+	cmd.Command = fmt.Sprintf("vm config state %s.state", snap)
 	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
-		return fmt.Errorf("configuring migrate file for VM %s: %w", vmName, err)
+		return fmt.Errorf("configuring state file for VM %s: %w", vmName, err)
 	}
 
 	cmd.Command = fmt.Sprintf("vm config disk %s.hdd,writeback", snap)

--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -819,19 +819,19 @@ func Snapshot(expName, vmName, out string, cb func(string)) error { //nolint:fun
 
 	host := status[0]["host"]
 
-	// ***** BEGIN: MIGRATE VM *****
+	// ***** BEGIN: SAVE VM *****
 
-	cmd.Command = fmt.Sprintf("vm migrate %s %s", vmName, out)
+	cmd.Command = fmt.Sprintf("vm save %s %s", vmName, out)
 
 	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
 		return fmt.Errorf("starting memory snapshot for VM %s: %w", vmName, err)
 	}
 
-	cmd.Command = "vm migrate"
+	cmd.Command = "vm save"
 	cmd.Columns = []string{"name", "status", "complete (%)"}
 	cmd.Filters = []string{"name=" + vmName}
 
-	// Adding a 1 second delay before calling "vm migrate"
+	// Adding a 1 second delay before calling "vm save"
 	// for a status update appears to prevent the status call
 	// from crashing minimega
 	time.Sleep(1 * time.Second)
@@ -855,7 +855,7 @@ func Snapshot(expName, vmName, out string, cb func(string)) error { //nolint:fun
 		time.Sleep(1 * time.Second)
 	}
 
-	// ***** END: MIGRATE VM *****
+	// ***** END: SAVE VM *****
 
 	cmd.Command = "vm start " + vmName
 
@@ -949,9 +949,9 @@ func Restore(expName, vmName, snap string) error {
 		return fmt.Errorf("setting uuid for VM %s: %w", vmName, err)
 	}
 
-	cmd.Command = fmt.Sprintf("vm config migrate %s.state", snap)
+	cmd.Command = fmt.Sprintf("vm config state %s.state", snap)
 	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
-		return fmt.Errorf("configuring migrate file for VM %s: %w", vmName, err)
+		return fmt.Errorf("configuring state file for VM %s: %w", vmName, err)
 	}
 
 	cmd.Command = fmt.Sprintf("vm config disk %s.hdd,writeback", snap)

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -381,7 +381,7 @@ func (Minimega) RedeployVM(opts ...Option) error { //nolint:funlen // complex lo
 		return fmt.Errorf("cloning VM %s in namespace %s: %w", o.vm, o.ns, err)
 	}
 
-	cmd.Command = "clear vm config migrate"
+	cmd.Command = "clear vm config state"
 
 	err = mmcli.ErrorResponse(mmcli.Run(cmd))
 	if err != nil {

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -409,7 +409,7 @@ func (Minimega) RedeployVM(opts ...Option) error { //nolint:funlen // complex lo
 		return fmt.Errorf("cloning VM %s in namespace %s: %w", o.vm, o.ns, err)
 	}
 
-	cmd.Command = "clear vm config migrate"
+	cmd.Command = "clear vm config state"
 
 	err = mmcli.ErrorResponse(mmcli.Run(cmd))
 	if err != nil {


### PR DESCRIPTION
## Summary

- replace deprecated `vm migrate` calls with `vm save`
- restore snapshots with `vm config state`
- clear saved state with `clear vm config state` during redeployment
- document the command migration in the changelog

## Backing image impact

Backing-image creation is unaffected. `CommitToDisk` copies the VM disk snapshot and uses `qemu-img rebase`/`qemu-img commit`; it does not call the deprecated `vm migrate` command.

## Validation

- `cd src/go && go test -race ./api/vm ./util/mm`
- `cd src/go && golangci-lint run -c .golangci.yml --new-from-rev upstream/main ./api/vm/... ./util/mm/...`
- verified no deprecated `vm migrate` or `vm config migrate` commands remain