### PR TITLE
feat(soh): add host file absence checks

### DIFF
--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -221,6 +221,7 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 			"reachability":        true,
 			"custom-reachability": true,
 			"files":               true,
+			"files-absent":        true,
 			"processes":           true,
 			"ports":               true,
 			"custom":              true,
@@ -420,6 +421,17 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 
 	if checks["files"] {
 		err := s.waitForFileTest(ctx, ns)
+		s.writeResults(exp)
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		errs = errs || err
+	}
+
+	if checks["files-absent"] {
+		err := s.waitForFileAbsentTest(ctx, ns)
 		s.writeResults(exp)
 
 		if ctx.Err() != nil {

--- a/src/go/api/soh/soh_test.go
+++ b/src/go/api/soh/soh_test.go
@@ -12,15 +12,17 @@ func TestHostStateAllStatesIncludesFiles(t *testing.T) {
 
 	networking := State{Success: "network configured"}
 	file := State{Success: "file found"}
+	fileAbsent := State{Success: "file not found"}
 	process := State{Success: "process running"}
 
 	state := HostState{
-		Networking: []State{networking},
-		Files:      []State{file},
-		Processes:  []State{process},
+		Networking:  []State{networking},
+		Files:       []State{file},
+		FilesAbsent: []State{fileAbsent},
+		Processes:   []State{process},
 	}
 
-	want := []State{networking, file, process}
+	want := []State{networking, file, fileAbsent, process}
 	if got := state.AllStates(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("AllStates() = %#v, want %#v", got, want)
 	}
@@ -42,6 +44,29 @@ func TestSOHMetadataDecodesHostFiles(t *testing.T) {
 
 	if !reflect.DeepEqual(metadata.HostFiles, input["hostFiles"]) {
 		t.Fatalf("HostFiles = %#v, want %#v", metadata.HostFiles, input["hostFiles"])
+	}
+}
+
+func TestSOHMetadataDecodesHostFilesAbsent(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"hostFilesAbsent": map[string][]string{
+			"server": {"/tmp/should-not-exist.txt", "/opt/removed.txt"},
+		},
+	}
+
+	var metadata sohMetadata
+	if err := mapstructure.Decode(input, &metadata); err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+
+	if !reflect.DeepEqual(metadata.HostFilesAbsent, input["hostFilesAbsent"]) {
+		t.Fatalf(
+			"HostFilesAbsent = %#v, want %#v",
+			metadata.HostFilesAbsent,
+			input["hostFilesAbsent"],
+		)
 	}
 }
 

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -53,6 +53,7 @@ type HostState struct {
 	Networking   []State `json:"networking,omitempty"   mapstructure:"networking,omitempty"   structs:"networking,omitempty"`
 	Reachability []State `json:"reachability,omitempty" mapstructure:"reachability,omitempty" structs:"reachability,omitempty"`
 	Files        []State `json:"files,omitempty"        mapstructure:"files,omitempty"        structs:"files,omitempty"`
+	FilesAbsent  []State `json:"filesAbsent,omitempty"  mapstructure:"filesAbsent,omitempty"  structs:"filesAbsent,omitempty"`
 	Processes    []State `json:"processes,omitempty"    mapstructure:"processes,omitempty"    structs:"processes,omitempty"`
 	Listeners    []State `json:"listeners,omitempty"    mapstructure:"listeners,omitempty"    structs:"listeners,omitempty"`
 	CustomTests  []State `json:"customTests,omitempty"  mapstructure:"customTests,omitempty"  structs:"customTests,omitempty"`
@@ -62,17 +63,15 @@ type HostState struct {
 }
 
 func (h HostState) AllStates() []State {
-	all := make(
-		[]State,
-		0,
-		len(h.Networking)+len(h.Reachability)+len(h.Files)+len(h.Processes)+len(h.Listeners)+len(
-			h.CustomTests,
-		),
-	)
+	total := len(h.Networking) + len(h.Reachability) + len(h.Files) + len(h.FilesAbsent) +
+		len(h.Processes) + len(h.Listeners) + len(h.CustomTests)
+
+	all := make([]State, 0, total)
 
 	all = append(all, h.Networking...)
 	all = append(all, h.Reachability...)
 	all = append(all, h.Files...)
+	all = append(all, h.FilesAbsent...)
 	all = append(all, h.Processes...)
 	all = append(all, h.Listeners...)
 	all = append(all, h.CustomTests...)
@@ -130,6 +129,7 @@ type sohMetadata struct {
 	C2Timeout          string                      `mapstructure:"c2Timeout"`
 	ExitOnError        bool                        `mapstructure:"exitOnError"`
 	HostFiles          map[string][]string         `mapstructure:"hostFiles"`
+	HostFilesAbsent    map[string][]string         `mapstructure:"hostFilesAbsent"`
 	HostListeners      map[string][]string         `mapstructure:"hostListeners"`
 	HostProcesses      map[string][]string         `mapstructure:"hostProcesses"`
 	CustomHostTests    map[string][]customHostTest `mapstructure:"hostCustomTests"`

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -605,13 +605,29 @@ func (s *SOH) waitForReachabilityTest(ctx context.Context, ns string, checks map
 	return wg.ErrCount > 0
 }
 
-func (s *SOH) waitForFileTest(ctx context.Context, ns string) bool {
+// fileExistenceTestFn matches the signature shared by fileTest and fileAbsentTest.
+type fileExistenceTestFn func(ctx context.Context, wg *mm.StateGroup, ns string, node ifaces.NodeSpec, path string)
+
+// waitForFileExistenceTest runs the given file existence test (fileTest or
+// fileAbsentTest) for each host/path pair in hostFiles, then records results
+// into the host state field selected by assign. This is shared by
+// waitForFileTest and waitForFileAbsentTest since they only differ by which
+// test is run, what gets logged, and where results are stored.
+func (s *SOH) waitForFileExistenceTest(
+	ctx context.Context,
+	ns string,
+	hostFiles map[string][]string,
+	test fileExistenceTestFn,
+	waitMsg string,
+	notFoundLogMsg string,
+	assign func(*HostState, State),
+) bool {
 	var (
 		logger = plog.LoggerFromContext(ctx, plog.TypeSoh)
 		wg     = new(mm.StateGroup)
 	)
 
-	for host, files := range s.md.HostFiles {
+	for host, files := range hostFiles {
 		if _, ok := s.c2Hosts[host]; !ok {
 			logger.Debug("skipping host per config", "host", host)
 
@@ -619,12 +635,12 @@ func (s *SOH) waitForFileTest(ctx context.Context, ns string) bool {
 		}
 
 		for _, path := range files {
-			logger.Debug("checking for file on host", "host", host, "path", path)
-			s.fileTest(ctx, wg, ns, s.nodes[host], path)
+			logger.Debug("checking file on host", "host", host, "path", path)
+			test(ctx, wg, ns, s.nodes[host], path)
 		}
 	}
 
-	cancel := periodicallyNotify(ctx, "waiting for file tests to complete...", notifyInterval)
+	cancel := periodicallyNotify(ctx, waitMsg, notifyInterval)
 
 	wg.Wait()
 	cancel()
@@ -648,7 +664,7 @@ func (s *SOH) waitForFileTest(ctx context.Context, ns string) bool {
 
 			st.Error = err.Error()
 
-			logger.Error("[✗] file not found on host", "host", host, "path", path)
+			logger.Error(notFoundLogMsg, "host", host, "path", path)
 		} else {
 			st.Success = state.Msg
 		}
@@ -658,11 +674,39 @@ func (s *SOH) waitForFileTest(ctx context.Context, ns string) bool {
 			hostState = HostState{Hostname: host} //nolint:exhaustruct // partial initialization
 		}
 
-		hostState.Files = append(hostState.Files, st)
+		assign(&hostState, st)
 		s.status[host] = hostState
 	}
 
 	return wg.ErrCount > 0
+}
+
+func (s *SOH) waitForFileTest(ctx context.Context, ns string) bool {
+	return s.waitForFileExistenceTest(
+		ctx,
+		ns,
+		s.md.HostFiles,
+		s.fileTest,
+		"waiting for file tests to complete...",
+		"[✗] file not found on host",
+		func(hostState *HostState, st State) {
+			hostState.Files = append(hostState.Files, st)
+		},
+	)
+}
+
+func (s *SOH) waitForFileAbsentTest(ctx context.Context, ns string) bool {
+	return s.waitForFileExistenceTest(
+		ctx,
+		ns,
+		s.md.HostFilesAbsent,
+		s.fileAbsentTest,
+		"waiting for file absence tests to complete...",
+		"[✗] file found on host",
+		func(hostState *HostState, st State) {
+			hostState.FilesAbsent = append(hostState.FilesAbsent, st)
+		},
+	)
 }
 
 //nolint:dupl // similar to waitForPortTest
@@ -1447,6 +1491,43 @@ func fileCheckCommand(osType, path string) string {
 	path = strings.ReplaceAll(path, "'", `'"'"'`)
 
 	return fmt.Sprintf("stat -c present -- '%s'", path)
+}
+
+func (s SOH) fileAbsentTest(
+	ctx context.Context,
+	wg *mm.StateGroup,
+	ns string,
+	node ifaces.NodeSpec,
+	path string,
+) {
+	var (
+		host = node.General().Hostname()
+		meta = map[string]any{"host": host, "path": path}
+	)
+
+	retries := 5
+	expected := func(resp string) error {
+		if strings.TrimSpace(resp) == "present" {
+			if retries > 0 {
+				retries--
+
+				return mm.C2RetryError{Delay: c2RetryDelay}
+			}
+
+			return errors.New("file exists")
+		}
+
+		wg.AddSuccess("file not found", meta)
+
+		return nil
+	}
+
+	cmd := s.newParallelCommand(ns, host, fileCheckCommand(node.Hardware().OSType(), path))
+	cmd.Wait = wg
+	cmd.Meta = meta
+	cmd.Expected = expected
+
+	mm.ScheduleC2ParallelCommand(ctx, cmd)
 }
 
 func (s SOH) portTest(

--- a/src/js/src/views/StateOfHealth.vue
+++ b/src/js/src/views/StateOfHealth.vue
@@ -173,6 +173,42 @@
               </b-table>
               <br />
             </div>
+            <div v-if="detailsModal.soh.filesAbsent">
+              <p class="title is-6">Files (Absent)</p>
+              <b-table
+                :data="detailsModal.soh.filesAbsent"
+                default-sort="timestamp">
+                <b-table-column
+                  field="timestamp"
+                  label="Timestamp"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column
+                  field="path"
+                  label="Path"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.metadata.path }}
+                </b-table-column>
+                <b-table-column
+                  field="success"
+                  label="Success"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.success }}
+                </b-table-column>
+                <b-table-column
+                  field="error"
+                  label="Error"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
+              </b-table>
+              <br />
+            </div>
             <div v-if="detailsModal.soh.listeners">
               <p class="title is-6">Listeners</p>
               <b-table


### PR DESCRIPTION
## Description
Adds `hostFilesAbsent` config to the `soh` app — the inverse of `hostFiles` — to verify that a file does **NOT** exist on a host, per the first item requested in #352.

- New `hostFilesAbsent: map[hostname][]path` scenario app metadata field
- New `files-absent` check (enabled by default, can be disabled via runtime `checks` selection like other checks)
- New `FilesAbsent` field on `HostState`, included in `AllStates()`
- SoH UI details modal now renders a "Files (Absent)" table alongside the existing "Files" table

## Related Issue
Addresses part of #352 (file non-existence checks). The remaining items in that issue (`hostServices`, `dockerContainers`, and refactoring the repeated SoH check logic) are out of scope for this PR and can be tracked as follow-ups.

## Type of Change
- [x] New feature

## Testing
- `go test ./api/soh/...` (added tests: metadata decode for `hostFilesAbsent`, `HostState.AllStates()` now includes `FilesAbsent`)
- `go build ./api/soh/...`
- `gofmt -l` clean

## Checklist
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have tested my code.