### PR TITLE
feat(vm): add CLI command to mount/unmount VM filesystems

### DIFF
--- a/src/go/api/vm/mount.go
+++ b/src/go/api/vm/mount.go
@@ -1,0 +1,187 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"phenix/api/experiment"
+	"phenix/util/mm"
+	"phenix/util/plog"
+)
+
+// MountTimeout is how long to wait for a mount/unmount C2 command to complete.
+const MountTimeout = 5 * time.Second
+
+func init() { //nolint:gochecknoinits // registering experiment lifecycle hooks
+	// Make sure VM filesystem mounts don't outlive their experiment. Without
+	// this, a forgotten mount can leave a stale FUSE mount on the headnode
+	// that requires a reboot to clear once the backing VM is gone.
+	experiment.RegisterHook("stop", func(_, expName string) { unmountExperiment(expName) })
+	experiment.RegisterHook("delete", func(_, expName string) { unmountExperiment(expName) })
+}
+
+// Mount mounts the filesystem of the given running VM to hostPath. If
+// hostPath is empty, the default phenix mount path
+// (<mount-dir>/<experiment>/<vm-name>) is used instead. It returns the
+// resolved host path the VM was mounted to, along with any errors encountered.
+//
+// This is the same implementation used by the `POST
+// /experiments/{exp}/vms/{name}/mount` API endpoint, so behavior is
+// consistent between the CLI and web UI.
+func Mount(expName, vmName, hostPath string) (string, error) {
+	if expName == "" {
+		return "", errors.New("no experiment name provided")
+	}
+
+	if vmName == "" {
+		return "", errors.New("no VM name provided")
+	}
+
+	details, err := Get(expName, vmName)
+	if err != nil {
+		return "", fmt.Errorf("getting VM details: %w", err)
+	}
+
+	if !details.Running {
+		return "", errors.New("vm is not running")
+	}
+
+	if err := mm.IsC2ClientActive(
+		mm.C2NS(expName),
+		mm.C2VM(vmName),
+		mm.C2IDClientsByUUID(),
+		mm.C2Timeout(MountTimeout),
+	); err != nil {
+		return "", fmt.Errorf("vm's C2 agent (miniccc) is not reachable: %w", err)
+	}
+
+	if hostPath == "" {
+		hostPath = mm.GetLocalMountPath(expName, vmName)
+	}
+
+	hostPath, err = filepath.Abs(hostPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving mount path: %w", err)
+	}
+
+	if err := os.MkdirAll(hostPath, 0o750); err != nil {
+		return "", fmt.Errorf("creating mount directory %s: %w", hostPath, err)
+	}
+
+	if err := MountFilesystem(expName, vmName); err != nil {
+		return "", err
+	}
+
+	plog.Info(plog.TypeAction, "vm mounted", "exp", expName, "vm", vmName, "path", hostPath)
+
+	return hostPath, nil
+}
+
+// Unmount unmounts the filesystem of the given VM. It returns any errors
+// encountered while unmounting.
+//
+// This is the same implementation used by the `POST
+// /experiments/{exp}/vms/{name}/unmount` API endpoint, so behavior is
+// consistent between the CLI and web UI.
+func Unmount(expName, vmName string) error {
+	if expName == "" {
+		return errors.New("no experiment name provided")
+	}
+
+	if vmName == "" {
+		return errors.New("no VM name provided")
+	}
+
+	if err := UnmountFilesystem(expName, vmName); err != nil {
+		return err
+	}
+
+	plog.Info(plog.TypeAction, "vm unmounted", "exp", expName, "vm", vmName)
+
+	return nil
+}
+
+// MountFilesystem issues the C2 command to mount a VM's filesystem, tolerating
+// the case where it's already mounted. It is used by both the CLI (via Mount)
+// and the `POST /experiments/{exp}/vms/{name}/mount` API endpoint.
+func MountFilesystem(expName, vmName string) error {
+	_, err := mm.ExecC2Command(
+		mm.C2NS(expName),
+		mm.C2VM(vmName),
+		mm.C2Mount(),
+		mm.C2IDClientsByUUID(),
+		mm.C2Timeout(MountTimeout),
+	)
+
+	if err != nil && !strings.Contains(err.Error(), "already connected") {
+		return fmt.Errorf("mounting VM filesystem: %w", err)
+	}
+
+	return nil
+}
+
+// UnmountFilesystem issues the C2 command to unmount a VM's filesystem. It is
+// used by both the CLI (via Unmount) and the `POST
+// /experiments/{exp}/vms/{name}/unmount` API endpoint.
+func UnmountFilesystem(expName, vmName string) error {
+	_, err := mm.ExecC2Command(
+		mm.C2NS(expName),
+		mm.C2VM(vmName),
+		mm.C2Unmount(),
+		mm.C2Timeout(MountTimeout),
+		mm.C2SkipActiveClientCheck(true),
+	)
+	if err != nil {
+		return fmt.Errorf("unmounting VM filesystem: %w", err)
+	}
+
+	return nil
+}
+
+// unmountExperiment unmounts any VM filesystems still mounted for the given
+// experiment and removes the experiment's mount directory. Errors are logged
+// but not returned since this is invoked from experiment lifecycle hooks.
+func unmountExperiment(expName string) {
+	vms, err := List(expName)
+	if err != nil {
+		plog.Warn(plog.TypeSystem, "listing VMs to unmount", "exp", expName, "err", err)
+	}
+
+	for _, v := range vms {
+		if err := UnmountFilesystem(expName, v.Name); err != nil {
+			plog.Warn(
+				plog.TypeSystem,
+				"unmounting vm during experiment cleanup",
+				"exp",
+				expName,
+				"vm",
+				v.Name,
+				"err",
+				err,
+			)
+		}
+	}
+
+	mountDir := mm.GetLocalMountPath(expName, "")
+
+	if _, err := os.Stat(mountDir); err != nil {
+		return
+	}
+
+	if err := os.RemoveAll(mountDir); err != nil {
+		plog.Warn(
+			plog.TypeSystem,
+			"removing experiment mount directory",
+			"exp",
+			expName,
+			"path",
+			mountDir,
+			"err",
+			err,
+		)
+	}
+}

--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -35,6 +35,7 @@ const (
 var (
 	phenixBase         string   //nolint:gochecknoglobals // global flag
 	minimegaBase       string   //nolint:gochecknoglobals // global flag
+	mountDir           string   //nolint:gochecknoglobals // global flag
 	hostnameSuffixes   string   //nolint:gochecknoglobals // global flag
 	storeEndpoint      string   //nolint:gochecknoglobals // global flag
 	currentConsoleFile *os.File //nolint:gochecknoglobals // global state
@@ -148,6 +149,10 @@ var rootCmd = &cobra.Command{
 		common.MinimegaBase = getEffectiveString( //nolint:reassign // configuration injection
 			"base-dir.minimega",
 			cmd.Flags().Changed("base-dir.minimega"),
+		)
+		common.MountBase = getEffectiveString( //nolint:reassign // configuration injection
+			"mount-dir",
+			cmd.Flags().Changed("mount-dir"),
 		)
 		common.HostnameSuffixes = getEffectiveString( //nolint:reassign // configuration injection
 			"hostname-suffixes",
@@ -377,6 +382,8 @@ func init() {
 		StringVar(&phenixBase, "base-dir.phenix", "/phenix", "base phenix directory")
 	rootCmd.PersistentFlags().
 		StringVar(&minimegaBase, "base-dir.minimega", "/tmp/minimega", "base minimega directory")
+	rootCmd.PersistentFlags().
+		StringVar(&mountDir, "mount-dir", "", "base directory for VM filesystem mounts (default: <base-dir.phenix>/mounts)")
 	rootCmd.PersistentFlags().
 		StringVar(&hostnameSuffixes, "hostname-suffixes", "-minimega,-phenix", "hostname suffixes to strip")
 	rootCmd.PersistentFlags().String("log.level", "info", "level to log messages at")

--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -35,6 +35,8 @@ const (
 	stopSubnetArgs   = 2
 	stopAllArgs      = 1
 	memSnapArgs      = 3
+	mountArgs        = 2
+	unmountArgs      = 2
 )
 
 func vmArgsCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -1068,6 +1070,99 @@ func newVMMemorySnapshotCmd() *cobra.Command {
 	return cmd
 }
 
+func newVMMountCmd() *cobra.Command {
+	desc := `Mount a VM's filesystem on the headnode
+
+  Mount the filesystem of a running virtual machine to a directory on the
+  headnode. By default, the mount path will be <mount-dir>/<experiment
+  name>/<vm name> (see the --mount-dir root flag / PHENIX_MOUNT_DIR
+  environment variable). An optional host path can be specified to mount to a
+  custom location instead.`
+
+	cmd := &cobra.Command{
+		Use:               "mount <experiment name> <vm name> [host path]",
+		Short:             "Mount a VM's filesystem on the headnode",
+		Long:              desc,
+		ValidArgsFunction: vmArgsCompletion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < mountArgs || len(args) > mountArgs+1 {
+				return errors.New(
+					"must provide an experiment name and VM name, optionally followed by a host path",
+				)
+			}
+
+			var (
+				expName  = args[0]
+				vmName   = args[1]
+				hostPath string
+			)
+
+			if len(args) == mountArgs+1 {
+				hostPath = args[2]
+			}
+
+			mountPath, err := vm.Mount(expName, vmName, hostPath)
+			if err != nil {
+				err := util.HumanizeError(err, "%s", "Unable to mount the "+vmName+" VM")
+
+				return err.Humanized()
+			}
+
+			fmt.Fprintf(os.Stdout, "VM %s in experiment %s mounted at: %s\n", vmName, expName, mountPath)
+			plog.Info(
+				plog.TypeSystem,
+				"vm mounted",
+				"vm",
+				vmName,
+				"exp",
+				expName,
+				"path",
+				mountPath,
+			)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func newVMUnmountCmd() *cobra.Command {
+	desc := `Unmount a VM's filesystem from the headnode
+
+  Unmount a previously mounted virtual machine filesystem from the headnode.`
+
+	cmd := &cobra.Command{
+		Use:               "unmount <experiment name> <vm name>",
+		Short:             "Unmount a VM's filesystem from the headnode",
+		Long:              desc,
+		ValidArgsFunction: vmArgsCompletion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != unmountArgs {
+				return errors.New("must provide an experiment name and VM name")
+			}
+
+			var (
+				expName = args[0]
+				vmName  = args[1]
+			)
+
+			if err := vm.Unmount(expName, vmName); err != nil {
+				err := util.HumanizeError(err, "%s", "Unable to unmount the "+vmName+" VM")
+
+				return err.Humanized()
+			}
+
+			fmt.Fprintf(os.Stdout, "VM %s in experiment %s unmounted\n", vmName, expName)
+			plog.Info(plog.TypeSystem, "vm unmounted", "vm", vmName, "exp", expName)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
 func init() { //nolint:gochecknoinits // cobra command
 	vmCmd := newVMCmd()
 
@@ -1083,6 +1178,8 @@ func init() { //nolint:gochecknoinits // cobra command
 	vmCmd.AddCommand(newVMNetCmd())
 	vmCmd.AddCommand(newVMCaptureCmd())
 	vmCmd.AddCommand(newVMMemorySnapshotCmd())
+	vmCmd.AddCommand(newVMMountCmd())
+	vmCmd.AddCommand(newVMUnmountCmd())
 
 	rootCmd.AddCommand(vmCmd)
 }

--- a/src/go/util/common/common.go
+++ b/src/go/util/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -29,6 +30,10 @@ var (
 	PhenixBase   = "/phenix"       //nolint:gochecknoglobals // global config
 	MinimegaBase = "/tmp/minimega" //nolint:gochecknoglobals // global config
 
+	// MountBase is the base directory used to store VM filesystem mounts. When
+	// empty, callers should default to PhenixBase + "/mounts".
+	MountBase string //nolint:gochecknoglobals // global config
+
 	BridgeMode = BridgeModeManual     //nolint:gochecknoglobals // global config
 	DeployMode = DeployModeNoHeadnode //nolint:gochecknoglobals // global config
 
@@ -39,6 +44,17 @@ var (
 
 	UseGREMesh bool //nolint:gochecknoglobals // global config
 )
+
+// MountDir returns the effective base directory to use for VM filesystem
+// mounts. If MountBase has not been explicitly configured, it defaults to
+// PhenixBase + "/mounts".
+func MountDir() string {
+	if MountBase == "" {
+		return filepath.Join(PhenixBase, "mounts")
+	}
+
+	return MountBase
+}
 
 func TrimHostnameSuffixes(str string) string {
 	for s := range strings.SplitSeq(HostnameSuffixes, ",") {

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -1490,7 +1490,7 @@ func (Minimega) MeshSend(ns, host, command string) error {
 // GetLocalMountPath returns where the mount path should be on this filesystem
 // for the given namespace and VM.
 func GetLocalMountPath(ns, vm string) string {
-	return filepath.Join(common.PhenixBase, "mounts", ns, vm)
+	return filepath.Join(common.MountDir(), ns, vm)
 }
 
 func getActiveC2(ns string) map[string]bool {

--- a/src/go/web/mount.go
+++ b/src/go/web/mount.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"phenix/api/experiment"
+	"phenix/api/vm"
 	"phenix/util/file"
 	"phenix/util/mm"
 	"phenix/util/plog"
@@ -24,10 +25,7 @@ import (
 	"phenix/web/rbac"
 )
 
-const (
-	MountTimeout     = 5 * time.Second
-	MountPathTimeout = 2 * time.Second
-)
+const MountPathTimeout = 2 * time.Second
 
 // MountInfo is a small struct for tracking number of users interacting with a mount and the
 // lock for that mount.
@@ -97,16 +95,7 @@ func MountVM(w http.ResponseWriter, r *http.Request) {
 			user,
 		)
 
-		_, err := mm.ExecC2Command(
-			mm.C2NS(vars["exp"]),
-			mm.C2VM(vars["name"]),
-			mm.C2Mount(),
-			mm.C2IDClientsByUUID(),
-			mm.C2Timeout(MountTimeout),
-		)
-
-		// if already mounted, that's ok, but still add to map
-		if err != nil && !strings.Contains(err.Error(), "already connected") {
+		if err := vm.MountFilesystem(vars["exp"], vars["name"]); err != nil {
 			plog.Error(plog.TypeSystem, "creating mount", "mount", mapKey, "err", err)
 			http.Error(w, fmt.Sprintf("Error mounting: %s", err), http.StatusInternalServerError)
 
@@ -160,14 +149,7 @@ func UnmountVM(w http.ResponseWriter, r *http.Request) {
 
 			mountInfo.lock.Lock()
 
-			_, err := mm.ExecC2Command(
-				mm.C2NS(vars["exp"]),
-				mm.C2VM(vars["name"]),
-				mm.C2Unmount(),
-				mm.C2Timeout(MountTimeout),
-				mm.C2SkipActiveClientCheck(true),
-			)
-			if err != nil {
+			if err := vm.UnmountFilesystem(vars["exp"], vars["name"]); err != nil {
 				mountInfo.lock.Unlock()
 
 				plog.Error(plog.TypeSystem, "unmounting", "mount", mapKey, "err", err)


### PR DESCRIPTION
## Description
Adds `phenix vm mount <exp> <vm> [host-path]` and `phenix vm unmount <exp> <vm>` CLI commands so phenix can manage mounting a VM's filesystem on the headnode, instead of users manually running `mm cc mount` and cleaning up afterwards. The mount/unmount logic is shared between the CLI and the existing `/mount` and `/unmount` web API endpoints. Experiment "stop"/"delete" hooks automatically unmount VMs and clean up mount directories so mounts can't outlive their experiment. Adds a `PHENIX_MOUNT_DIR` setting (`--mount-dir` flag) that defaults to `<base-dir.phenix>/mounts`.

## Related Issue
Closes #363

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Verified with `go build ./...`, `go vet`, `gofmt -l`, and `go test ./cmd/... ./api/vm/...`. Documentation update for the new command/setting is still needed as a follow-up.
