### PR TITLE
feat(cli): add force flag to phenix exp delete

### DIFF
--- a/src/go/cmd/experiment.go
+++ b/src/go/cmd/experiment.go
@@ -309,7 +309,8 @@ func newExperimentDeleteCmd() *cobra.Command {
 
   Used to delete an existing experiment; experiment must be stopped.
   Using 'all' instead of a specific experiment name will include all
-  stopped experiments`
+  stopped experiments. Use the -f/--force flag to automatically stop
+  a running experiment before deleting it.`
 
 	cmd := &cobra.Command{
 		Use:               "delete <experiment name>",
@@ -320,6 +321,7 @@ func newExperimentDeleteCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name        = args[0]
+				force       = MustGetBool(cmd.Flags(), "force")
 				experiments []types.Experiment
 			)
 
@@ -345,14 +347,29 @@ func newExperimentDeleteCmd() *cobra.Command {
 
 			for _, exp := range experiments {
 				if exp.Running() {
-					plog.Warn(
-						plog.TypeSystem,
-						"not deleting running experiment",
-						"exp",
-						exp.Metadata.Name,
-					)
+					if !force {
+						plog.Warn(
+							plog.TypeSystem,
+							"not deleting running experiment",
+							"exp",
+							exp.Metadata.Name,
+						)
 
-					continue
+						continue
+					}
+
+					if err := experiment.Stop(exp.Metadata.Name); err != nil {
+						err := util.HumanizeError(
+							err,
+							"%s",
+							"Unable to stop the "+exp.Metadata.Name+" experiment before deleting it",
+						)
+						plog.Error(plog.TypeSystem, err.Humanize())
+
+						continue
+					}
+
+					plog.Info(plog.TypeSystem, "experiment stopped", "exp", exp.Metadata.Name)
 				}
 
 				err := config.Delete("experiment/" + exp.Metadata.Name)
@@ -373,6 +390,8 @@ func newExperimentDeleteCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolP("force", "f", false, "Stop a running experiment before deleting it")
 
 	return cmd
 }

--- a/src/go/cmd/experiment_cmd_test.go
+++ b/src/go/cmd/experiment_cmd_test.go
@@ -5,8 +5,54 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/activeshadow/structs"
+	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
+
+	"phenix/store"
+	"phenix/types"
+	"phenix/util/file"
+	"phenix/util/mm"
 )
+
+// fakeClusterFiles is a test double for file.ClusterFiles that no-ops
+// DeleteFile calls; any other method invocation will panic since the
+// embedded interface is left nil.
+type fakeClusterFiles struct {
+	file.ClusterFiles
+}
+
+func (fakeClusterFiles) DeleteFile(string) error { return nil }
+
+// fakeMM is a test double for mm.MM that no-ops the calls exercised when
+// deleting a dry-run experiment; any other method invocation will panic
+// since the embedded interface is left nil.
+type fakeMM struct {
+	mm.MM
+}
+
+func (fakeMM) Headnode() string            { return "test-headnode" }
+func (fakeMM) ClearNamespace(string) error { return nil }
+
+// newRunningDryRunExperimentConfig builds a store.Config for an experiment
+// that is running in dry-run mode, so that experiment.Stop can be exercised
+// in tests without requiring a real minimega cluster.
+func newRunningDryRunExperimentConfig(name string, baseDir string) store.Config {
+	exp := types.NewExperiment(store.ConfigMetadata{Name: name})
+	exp.Spec.SetExperimentName(name)
+	exp.Spec.SetBaseDir(baseDir)
+	exp.Status.SetStartTime("2024-01-01T00:00:00-DRYRUN")
+
+	return store.Config{
+		Version: "phenix.sandia.gov/v1",
+		Kind:    "Experiment",
+		Metadata: store.ConfigMetadata{
+			Name: name,
+		},
+		Spec:   structs.MapDefaultCase(exp.Spec, structs.CASESNAKE),
+		Status: structs.MapDefaultCase(exp.Status, structs.CASESNAKE),
+	}
+}
 
 func TestExperimentCommandsShowUsageForMissingArguments(t *testing.T) {
 	tests := []struct {
@@ -63,5 +109,97 @@ func TestExperimentScheduleUsageDescribesArgumentOrder(t *testing.T) {
 	want := "Usage:\n  schedule <experiment name> <algorithm>"
 	if got := err.Error(); !strings.Contains(got, want) {
 		t.Fatalf("expected error to contain %q, got:\n%s", want, got)
+	}
+}
+
+func TestExperimentDeleteForceFlagDefaultsToFalse(t *testing.T) {
+	cmd := newExperimentDeleteCmd()
+
+	flag := cmd.Flags().Lookup("force")
+	if flag == nil {
+		t.Fatal("expected delete command to have a force flag")
+	}
+
+	if flag.Shorthand != "f" {
+		t.Fatalf("expected force flag shorthand to be %q, got %q", "f", flag.Shorthand)
+	}
+
+	if flag.DefValue != "false" {
+		t.Fatalf("expected force flag to default to false, got %q", flag.DefValue)
+	}
+}
+
+func TestExperimentDeleteSkipsRunningExperimentWithoutForce(t *testing.T) {
+	name := "running-exp"
+	cfg := newRunningDryRunExperimentConfig(name, t.TempDir())
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m := store.NewMockStore(ctrl)
+	m.EXPECT().Get(gomock.Any()).DoAndReturn(func(c *store.Config) error {
+		*c = cfg
+		return nil
+	}).Times(1)
+
+	store.DefaultStore = m //nolint:reassign // monkey patching for test
+
+	root := &cobra.Command{Use: "phenix", SilenceUsage: true}
+	experimentCmd := newExperimentCmd()
+	experimentCmd.AddCommand(newExperimentDeleteCmd())
+	root.AddCommand(experimentCmd)
+	root.SetArgs([]string{"experiment", "delete", name})
+
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExperimentDeleteForceStopsRunningExperimentBeforeDeleting(t *testing.T) {
+	name := "running-exp-force"
+	cfg := newRunningDryRunExperimentConfig(name, t.TempDir())
+
+	originalMM := mm.DefaultMM
+	originalClusterFiles := file.DefaultClusterFiles
+	t.Cleanup(func() {
+		mm.DefaultMM = originalMM                       //nolint:reassign // restore test double
+		file.DefaultClusterFiles = originalClusterFiles //nolint:reassign // restore test double
+	})
+
+	mm.DefaultMM = fakeMM{}                       //nolint:reassign // install test double
+	file.DefaultClusterFiles = fakeClusterFiles{} //nolint:reassign // install test double
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m := store.NewMockStore(ctrl)
+	m.EXPECT().Get(gomock.Any()).DoAndReturn(func(c *store.Config) error {
+		*c = cfg
+		return nil
+	}).AnyTimes()
+	m.EXPECT().Update(gomock.Any()).DoAndReturn(func(c *store.Config) error {
+		cfg = *c
+		return nil
+	}).Times(1)
+	m.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+
+	store.DefaultStore = m //nolint:reassign // monkey patching for test
+
+	root := &cobra.Command{Use: "phenix", SilenceUsage: true}
+	experimentCmd := newExperimentCmd()
+	experimentCmd.AddCommand(newExperimentDeleteCmd())
+	root.AddCommand(experimentCmd)
+	root.SetArgs([]string{"experiment", "delete", "--force", name})
+
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Description
Adds a `-f`/`--force` flag to `phenix exp delete`, similar to `docker rm -f`. When set, a running experiment is stopped automatically before being deleted, instead of requiring a separate `phenix exp stop` call first.

One less command I have to type means one additional second of peace for my fingers. This flag is essential to realize that dream.

## Related Issue
Closes #351

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Unit tests added in `src/go/cmd/experiment_cmd_test.go` cover: the flag's default/shorthand, that a running experiment is skipped without `--force`, and that `--force` stops then deletes a running (dry-run) experiment end-to-end via a mocked store.

Documentation update for `sandialabs/sceptre-phenix-docs` is planned as a follow-up in a separate PR against that repo.

Tested by starting an experiment, then running `phenix exp delete -f helloworld` and:

```
2026-08-11 23:27:42.997 INF [✓] 'scorch' user app (cleanup) type=PHENIX-APP
2026-08-11 23:27:43.005 INF [✓] 'soh' user app (cleanup) type=PHENIX-APP
2026-08-11 23:27:43.605 INF experiment stopped type=SYSTEM exp=helloworld
2026-08-11 23:27:43.614 INF experiment deleted type=SYSTEM exp=helloworld
```