### PR TITLE
feat(soh): add hostServices check for service state validation

### DIFF
--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -222,6 +222,7 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 			"custom-reachability": true,
 			"files":               true,
 			"files-absent":        true,
+			"services":            true,
 			"processes":           true,
 			"ports":               true,
 			"custom":              true,
@@ -432,6 +433,17 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 
 	if checks["files-absent"] {
 		err := s.waitForFileAbsentTest(ctx, ns)
+		s.writeResults(exp)
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		errs = errs || err
+	}
+
+	if checks["services"] {
+		err := s.waitForServiceTest(ctx, ns)
 		s.writeResults(exp)
 
 		if ctx.Err() != nil {

--- a/src/go/api/soh/soh_test.go
+++ b/src/go/api/soh/soh_test.go
@@ -13,16 +13,18 @@ func TestHostStateAllStatesIncludesFiles(t *testing.T) {
 	networking := State{Success: "network configured"}
 	file := State{Success: "file found"}
 	fileAbsent := State{Success: "file not found"}
+	service := State{Success: "service running"}
 	process := State{Success: "process running"}
 
 	state := HostState{
 		Networking:  []State{networking},
 		Files:       []State{file},
 		FilesAbsent: []State{fileAbsent},
+		Services:    []State{service},
 		Processes:   []State{process},
 	}
 
-	want := []State{networking, file, fileAbsent, process}
+	want := []State{networking, file, fileAbsent, service, process}
 	if got := state.AllStates(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("AllStates() = %#v, want %#v", got, want)
 	}
@@ -99,6 +101,59 @@ func TestFileCheckCommand(t *testing.T) {
 
 			if got := fileCheckCommand(test.osType, test.path); got != test.want {
 				t.Fatalf("fileCheckCommand() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSOHMetadataDecodesHostServices(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"hostServices": map[string][]string{
+			"server": {"sshd", "nginx"},
+		},
+	}
+
+	var metadata sohMetadata
+	if err := mapstructure.Decode(input, &metadata); err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+
+	if !reflect.DeepEqual(metadata.HostServices, input["hostServices"]) {
+		t.Fatalf("HostServices = %#v, want %#v", metadata.HostServices, input["hostServices"])
+	}
+}
+
+func TestServiceCheckCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		osType  string
+		service string
+		want    string
+	}{
+		{
+			name:    "linux",
+			osType:  "linux",
+			service: "user's service",
+			want:    `systemctl is-active -- 'user'"'"'s service'`,
+		},
+		{
+			name:    "windows",
+			osType:  "windows",
+			service: `O'Brien Service`,
+			want:    `powershell -NoProfile -Command "if ((Get-Service -Name 'O''Brien Service' -ErrorAction SilentlyContinue).Status -eq 'Running') { 'active' }"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := serviceCheckCommand(test.osType, test.service); got != test.want {
+				t.Fatalf("serviceCheckCommand() = %q, want %q", got, test.want)
 			}
 		})
 	}

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -54,6 +54,7 @@ type HostState struct {
 	Reachability []State `json:"reachability,omitempty" mapstructure:"reachability,omitempty" structs:"reachability,omitempty"`
 	Files        []State `json:"files,omitempty"        mapstructure:"files,omitempty"        structs:"files,omitempty"`
 	FilesAbsent  []State `json:"filesAbsent,omitempty"  mapstructure:"filesAbsent,omitempty"  structs:"filesAbsent,omitempty"`
+	Services     []State `json:"services,omitempty"     mapstructure:"services,omitempty"     structs:"services,omitempty"`
 	Processes    []State `json:"processes,omitempty"    mapstructure:"processes,omitempty"    structs:"processes,omitempty"`
 	Listeners    []State `json:"listeners,omitempty"    mapstructure:"listeners,omitempty"    structs:"listeners,omitempty"`
 	CustomTests  []State `json:"customTests,omitempty"  mapstructure:"customTests,omitempty"  structs:"customTests,omitempty"`
@@ -64,7 +65,7 @@ type HostState struct {
 
 func (h HostState) AllStates() []State {
 	total := len(h.Networking) + len(h.Reachability) + len(h.Files) + len(h.FilesAbsent) +
-		len(h.Processes) + len(h.Listeners) + len(h.CustomTests)
+		len(h.Services) + len(h.Processes) + len(h.Listeners) + len(h.CustomTests)
 
 	all := make([]State, 0, total)
 
@@ -72,6 +73,7 @@ func (h HostState) AllStates() []State {
 	all = append(all, h.Reachability...)
 	all = append(all, h.Files...)
 	all = append(all, h.FilesAbsent...)
+	all = append(all, h.Services...)
 	all = append(all, h.Processes...)
 	all = append(all, h.Listeners...)
 	all = append(all, h.CustomTests...)
@@ -130,6 +132,7 @@ type sohMetadata struct {
 	ExitOnError        bool                        `mapstructure:"exitOnError"`
 	HostFiles          map[string][]string         `mapstructure:"hostFiles"`
 	HostFilesAbsent    map[string][]string         `mapstructure:"hostFilesAbsent"`
+	HostServices       map[string][]string         `mapstructure:"hostServices"`
 	HostListeners      map[string][]string         `mapstructure:"hostListeners"`
 	HostProcesses      map[string][]string         `mapstructure:"hostProcesses"`
 	CustomHostTests    map[string][]customHostTest `mapstructure:"hostCustomTests"`

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -709,6 +709,66 @@ func (s *SOH) waitForFileAbsentTest(ctx context.Context, ns string) bool {
 	)
 }
 
+func (s *SOH) waitForServiceTest(ctx context.Context, ns string) bool {
+	var (
+		logger = plog.LoggerFromContext(ctx, plog.TypeSoh)
+		wg     = new(mm.StateGroup)
+	)
+
+	for host, services := range s.md.HostServices {
+		if _, ok := s.c2Hosts[host]; !ok {
+			logger.Debug("skipping host per config", "host", host)
+
+			continue
+		}
+
+		for _, service := range services {
+			logger.Debug("checking for service on host", "host", host, "service", service)
+			s.serviceTest(ctx, wg, ns, s.nodes[host], service)
+		}
+	}
+
+	cancel := periodicallyNotify(ctx, "waiting for service tests to complete...", notifyInterval)
+
+	wg.Wait()
+	cancel()
+
+	for _, state := range wg.States {
+		var (
+			host, _    = state.Meta["host"].(string)
+			service, _ = state.Meta["service"].(string)
+		)
+
+		st := State{ //nolint:exhaustruct // partial initialization
+			Metadata:  state.Meta,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+
+		err := state.Err
+		if err != nil {
+			if errors.Is(err, mm.ErrC2ClientNotActive) {
+				delete(s.c2Hosts, host)
+			}
+
+			st.Error = err.Error()
+
+			logger.Error("[✗] service not running on host", "host", host, "service", service)
+		} else {
+			st.Success = state.Msg
+		}
+
+		hostState, ok := s.status[host]
+		if !ok {
+			hostState = HostState{Hostname: host} //nolint:exhaustruct // partial initialization
+		}
+
+		hostState.Services = append(hostState.Services, st)
+		s.status[host] = hostState
+	}
+
+	return wg.ErrCount > 0
+}
+
 //nolint:dupl // similar to waitForPortTest
 func (s *SOH) waitForProcTest(ctx context.Context, ns string) bool {
 	var (
@@ -1528,6 +1588,58 @@ func (s SOH) fileAbsentTest(
 	cmd.Expected = expected
 
 	mm.ScheduleC2ParallelCommand(ctx, cmd)
+}
+
+func (s SOH) serviceTest(
+	ctx context.Context,
+	wg *mm.StateGroup,
+	ns string,
+	node ifaces.NodeSpec,
+	service string,
+) {
+	var (
+		host = node.General().Hostname()
+		meta = map[string]any{"host": host, "service": service}
+	)
+
+	retries := 5
+	expected := func(resp string) error {
+		if strings.TrimSpace(resp) != "active" {
+			if retries > 0 {
+				retries--
+
+				return mm.C2RetryError{Delay: c2RetryDelay}
+			}
+
+			return errors.New("service not active")
+		}
+
+		wg.AddSuccess("service running", meta)
+
+		return nil
+	}
+
+	cmd := s.newParallelCommand(ns, host, serviceCheckCommand(node.Hardware().OSType(), service))
+	cmd.Wait = wg
+	cmd.Meta = meta
+	cmd.Expected = expected
+
+	mm.ScheduleC2ParallelCommand(ctx, cmd)
+}
+
+func serviceCheckCommand(osType, service string) string {
+	if strings.EqualFold(osType, "windows") {
+		service = strings.ReplaceAll(service, "'", "''")
+
+		return fmt.Sprintf(
+			`powershell -NoProfile -Command "if ((Get-Service -Name '%s' -ErrorAction SilentlyContinue).Status -eq 'Running') { 'active' }"`,
+			service,
+		)
+	}
+
+	service = strings.ReplaceAll(service, "'", `'"'"'`)
+
+	return fmt.Sprintf("systemctl is-active -- '%s'", service)
 }
 
 func (s SOH) portTest(

--- a/src/js/src/views/StateOfHealth.vue
+++ b/src/js/src/views/StateOfHealth.vue
@@ -209,6 +209,42 @@
               </b-table>
               <br />
             </div>
+            <div v-if="detailsModal.soh.services">
+              <p class="title is-6">Services</p>
+              <b-table
+                :data="detailsModal.soh.services"
+                default-sort="timestamp">
+                <b-table-column
+                  field="timestamp"
+                  label="Timestamp"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column
+                  field="service"
+                  label="Service"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.metadata.service }}
+                </b-table-column>
+                <b-table-column
+                  field="success"
+                  label="Success"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.success }}
+                </b-table-column>
+                <b-table-column
+                  field="error"
+                  label="Error"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
+              </b-table>
+              <br />
+            </div>
             <div v-if="detailsModal.soh.listeners">
               <p class="title is-6">Listeners</p>
               <b-table


### PR DESCRIPTION
## Description
Adds `hostServices` checks to the SoH app, letting scenarios validate that specific system services are running on Linux (via `systemctl is-active`) and Windows (via `Get-Service`) hosts. Follows the same pattern as the recently merged `hostFiles` check.

Example scenario config:
```yaml
hostServices:
  webserver:
    - nginx
    - sshd
```

## Related Issue
Closes #352 (service checks portion; file-absence and Docker checks are left for follow-up work)

Docs PR: sandialabs/sceptre-phenix-docs#57

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Verified with manual testing on a phenix deployment. Tested with `phenix experiment trigger-running <exp> soh`, followed by verifying checks passed in logs, and the status is working in UI.
