### PR TITLE
feat(soh): add docker container health checks

### DIFF
--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -225,6 +225,7 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 			"services":            true,
 			"processes":           true,
 			"ports":               true,
+			"docker":              true,
 			"custom":              true,
 			"cpu-load":            true,
 			"flows":               true,
@@ -466,6 +467,17 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 
 	if checks["ports"] {
 		err := s.waitForPortTest(ctx, ns)
+		s.writeResults(exp)
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		errs = errs || err
+	}
+
+	if checks["docker"] {
+		err := s.waitForContainerTest(ctx, ns)
 		s.writeResults(exp)
 
 		if ctx.Err() != nil {

--- a/src/go/api/soh/soh_test.go
+++ b/src/go/api/soh/soh_test.go
@@ -15,6 +15,7 @@ func TestHostStateAllStatesIncludesFiles(t *testing.T) {
 	fileAbsent := State{Success: "file not found"}
 	service := State{Success: "service running"}
 	process := State{Success: "process running"}
+	container := State{Success: "container running"}
 
 	state := HostState{
 		Networking:  []State{networking},
@@ -22,9 +23,10 @@ func TestHostStateAllStatesIncludesFiles(t *testing.T) {
 		FilesAbsent: []State{fileAbsent},
 		Services:    []State{service},
 		Processes:   []State{process},
+		Containers:  []State{container},
 	}
 
-	want := []State{networking, file, fileAbsent, service, process}
+	want := []State{networking, file, fileAbsent, service, process, container}
 	if got := state.AllStates(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("AllStates() = %#v, want %#v", got, want)
 	}
@@ -68,6 +70,29 @@ func TestSOHMetadataDecodesHostFilesAbsent(t *testing.T) {
 			"HostFilesAbsent = %#v, want %#v",
 			metadata.HostFilesAbsent,
 			input["hostFilesAbsent"],
+		)
+	}
+}
+
+func TestSOHMetadataDecodesDockerContainers(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"dockerContainers": map[string][]string{
+			"server": {"nginx", "redis"},
+		},
+	}
+
+	var metadata sohMetadata
+	if err := mapstructure.Decode(input, &metadata); err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+
+	if !reflect.DeepEqual(metadata.HostContainers, input["dockerContainers"]) {
+		t.Fatalf(
+			"HostContainers = %#v, want %#v",
+			metadata.HostContainers,
+			input["dockerContainers"],
 		)
 	}
 }
@@ -154,6 +179,45 @@ func TestServiceCheckCommand(t *testing.T) {
 
 			if got := serviceCheckCommand(test.osType, test.service); got != test.want {
 				t.Fatalf("serviceCheckCommand() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestContainerCheckCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		osType    string
+		container string
+		want      string
+	}{
+		{
+			name:      "linux",
+			osType:    "linux",
+			container: "o'brien's-app",
+			want: `docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}` +
+				`{{else}}{{if .State.Running}}running{{else}}{{.State.Status}}{{end}}{{end}}' ` +
+				`-- 'o'"'"'brien'"'"'s-app'`,
+		},
+		{
+			name:      "windows",
+			osType:    "windows",
+			container: "o'brien's-app",
+			want: `powershell -NoProfile -Command "docker inspect --format='` +
+				`{{if .State.Health}}{{.State.Health.Status}}` +
+				`{{else}}{{if .State.Running}}running{{else}}{{.State.Status}}{{end}}{{end}}' ` +
+				`-- 'o''brien''s-app' 2>$null"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := containerCheckCommand(test.osType, test.container); got != test.want {
+				t.Fatalf("containerCheckCommand() = %q, want %q", got, test.want)
 			}
 		})
 	}

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -57,6 +57,7 @@ type HostState struct {
 	Services     []State `json:"services,omitempty"     mapstructure:"services,omitempty"     structs:"services,omitempty"`
 	Processes    []State `json:"processes,omitempty"    mapstructure:"processes,omitempty"    structs:"processes,omitempty"`
 	Listeners    []State `json:"listeners,omitempty"    mapstructure:"listeners,omitempty"    structs:"listeners,omitempty"`
+	Containers   []State `json:"containers,omitempty"   mapstructure:"containers,omitempty"   structs:"containers,omitempty"`
 	CustomTests  []State `json:"customTests,omitempty"  mapstructure:"customTests,omitempty"  structs:"customTests,omitempty"`
 
 	// populated before sending to UI client
@@ -65,7 +66,8 @@ type HostState struct {
 
 func (h HostState) AllStates() []State {
 	total := len(h.Networking) + len(h.Reachability) + len(h.Files) + len(h.FilesAbsent) +
-		len(h.Services) + len(h.Processes) + len(h.Listeners) + len(h.CustomTests)
+		len(h.Services) + len(h.Processes) + len(h.Listeners) + len(h.Containers) +
+		len(h.CustomTests)
 
 	all := make([]State, 0, total)
 
@@ -76,6 +78,7 @@ func (h HostState) AllStates() []State {
 	all = append(all, h.Services...)
 	all = append(all, h.Processes...)
 	all = append(all, h.Listeners...)
+	all = append(all, h.Containers...)
 	all = append(all, h.CustomTests...)
 
 	return all
@@ -135,6 +138,7 @@ type sohMetadata struct {
 	HostServices       map[string][]string         `mapstructure:"hostServices"`
 	HostListeners      map[string][]string         `mapstructure:"hostListeners"`
 	HostProcesses      map[string][]string         `mapstructure:"hostProcesses"`
+	HostContainers     map[string][]string         `mapstructure:"dockerContainers"`
 	CustomHostTests    map[string][]customHostTest `mapstructure:"hostCustomTests"`
 	InjectICMPAllow    bool                        `mapstructure:"injectICMPAllow"`
 	PacketCapture      packetCapture               `mapstructure:"packetCapture"`

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -709,6 +709,7 @@ func (s *SOH) waitForFileAbsentTest(ctx context.Context, ns string) bool {
 	)
 }
 
+//nolint:dupl // similar to waitForContainerTest
 func (s *SOH) waitForServiceTest(ctx context.Context, ns string) bool {
 	var (
 		logger = plog.LoggerFromContext(ctx, plog.TypeSoh)
@@ -763,6 +764,77 @@ func (s *SOH) waitForServiceTest(ctx context.Context, ns string) bool {
 		}
 
 		hostState.Services = append(hostState.Services, st)
+		s.status[host] = hostState
+	}
+
+	return wg.ErrCount > 0
+}
+
+//nolint:dupl // similar to waitForServiceTest
+func (s *SOH) waitForContainerTest(ctx context.Context, ns string) bool {
+	var (
+		logger = plog.LoggerFromContext(ctx, plog.TypeSoh)
+		wg     = new(mm.StateGroup)
+	)
+
+	for host, containers := range s.md.HostContainers {
+		if _, ok := s.c2Hosts[host]; !ok {
+			logger.Debug("skipping host per config", "host", host)
+
+			continue
+		}
+
+		for _, container := range containers {
+			logger.Debug("checking docker container on host", "host", host, "container", container)
+			s.containerTest(ctx, wg, ns, s.nodes[host], container)
+		}
+	}
+
+	cancel := periodicallyNotify(
+		ctx,
+		"waiting for docker container tests to complete...",
+		notifyInterval,
+	)
+
+	wg.Wait()
+	cancel()
+
+	for _, state := range wg.States {
+		var (
+			host, _      = state.Meta["host"].(string)
+			container, _ = state.Meta["container"].(string)
+		)
+
+		st := State{ //nolint:exhaustruct // partial initialization
+			Metadata:  state.Meta,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+
+		err := state.Err
+		if err != nil {
+			if errors.Is(err, mm.ErrC2ClientNotActive) {
+				delete(s.c2Hosts, host)
+			}
+
+			st.Error = err.Error()
+
+			logger.Error(
+				"[✗] docker container not up/healthy on host",
+				"host",
+				host,
+				"container",
+				container,
+			)
+		} else {
+			st.Success = state.Msg
+		}
+
+		hostState, ok := s.status[host]
+		if !ok {
+			hostState = HostState{Hostname: host} //nolint:exhaustruct // partial initialization
+		}
+
+		hostState.Containers = append(hostState.Containers, st)
 		s.status[host] = hostState
 	}
 
@@ -1640,6 +1712,90 @@ func serviceCheckCommand(osType, service string) string {
 	service = strings.ReplaceAll(service, "'", `'"'"'`)
 
 	return fmt.Sprintf("systemctl is-active -- '%s'", service)
+}
+
+func (s SOH) containerTest(
+	ctx context.Context,
+	wg *mm.StateGroup,
+	ns string,
+	node ifaces.NodeSpec,
+	container string,
+) {
+	var (
+		host = node.General().Hostname()
+		meta = map[string]any{"host": host, "container": container}
+	)
+
+	retries := 5
+	expected := func(resp string) error {
+		status := strings.ToLower(strings.TrimSpace(resp))
+
+		switch status {
+		case "healthy", "running":
+			wg.AddSuccess(fmt.Sprintf("container %s", status), meta)
+
+			return nil
+		case "unhealthy":
+			return errors.New("container unhealthy")
+		case "starting", "":
+			if retries > 0 {
+				retries--
+
+				return mm.C2RetryError{Delay: c2RetryDelay}
+			}
+
+			return errors.New("container not up")
+		default: // exited, dead, paused, restarting, created, or unknown container
+			if retries > 0 {
+				retries--
+
+				return mm.C2RetryError{Delay: c2RetryDelay}
+			}
+
+			return fmt.Errorf("container not up (state: %s)", status)
+		}
+	}
+
+	cmd := s.newParallelCommand(
+		ns,
+		host,
+		containerCheckCommand(node.Hardware().OSType(), container),
+	)
+	cmd.Wait = wg
+	cmd.Meta = meta
+	cmd.Expected = expected
+
+	mm.ScheduleC2ParallelCommand(ctx, cmd)
+}
+
+// containerCheckCommand builds a command that queries the state of a docker
+// container on the host. If the container has a configured healthcheck, its
+// health status (eg. "healthy", "unhealthy", "starting") is returned.
+// Otherwise, the container's run state (eg. "running", "exited") is returned.
+//
+// Note: commands are executed directly by the guest's C2 agent (miniccc),
+// not via a shell, so shell-only syntax (eg. stderr redirection) must not be
+// used here on Linux -- it would be passed through as a literal, unparsed
+// argument and corrupt the command. The Windows command is an exception
+// since it's wrapped in a `powershell -Command "..."` invocation, which
+// itself acts as an interpreter for the quoted script text.
+func containerCheckCommand(osType, container string) string {
+	const tmpl = `{{if .State.Health}}{{.State.Health.Status}}` +
+		`{{else}}{{if .State.Running}}running{{else}}{{.State.Status}}{{end}}{{end}}`
+
+	if strings.EqualFold(osType, "windows") {
+		container = strings.ReplaceAll(container, "'", "''")
+
+		return fmt.Sprintf(
+			`powershell -NoProfile -Command "docker inspect --format='%s' -- '%s' 2>$null"`,
+			tmpl,
+			container,
+		)
+	}
+
+	container = strings.ReplaceAll(container, "'", `'"'"'`)
+
+	return fmt.Sprintf("docker inspect --format='%s' -- '%s'", tmpl, container)
 }
 
 func (s SOH) portTest(

--- a/src/js/src/views/StateOfHealth.vue
+++ b/src/js/src/views/StateOfHealth.vue
@@ -281,6 +281,42 @@
               </b-table>
               <br />
             </div>
+            <div v-if="detailsModal.soh.containers">
+              <p class="title is-6">Docker Containers</p>
+              <b-table
+                :data="detailsModal.soh.containers"
+                default-sort="timestamp">
+                <b-table-column
+                  field="timestamp"
+                  label="Timestamp"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column
+                  field="container"
+                  label="Container"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.metadata.container }}
+                </b-table-column>
+                <b-table-column
+                  field="success"
+                  label="Success"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.success }}
+                </b-table-column>
+                <b-table-column
+                  field="error"
+                  label="Error"
+                  sortable
+                  v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
+              </b-table>
+              <br />
+            </div>
             <div v-if="detailsModal.soh.customTests">
               <p class="title is-6">Custom User Tests</p>
               <b-table :data="detailsModal.soh.customTests" default-sort="test">


### PR DESCRIPTION
## Description
Adds `dockerContainers` checks to the `soh` app: for each configured host/container, reports the container's Docker healthcheck status (`healthy`/`unhealthy`/`starting`) if a healthcheck is configured, otherwise falls back to its run state (e.g. `running`/`exited`). 

Added s "Docker Containers" table to node status in SoH UI.

Example scenario config:
```yaml
dockerContainers:
  server1:
    - nginx
    - redis
```

## Related Issue
Addresses the `dockerContainers` item from #352 (originally proposed in [PR #349's review discussion](https://github.com/sandialabs/sceptre-phenix/pull/349#pullrequestreview-4834899590)).

Documentation: https://github.com/sandialabs/sceptre-phenix-docs/pull/58

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Tested with `phenix experiment trigger-running <exp> soh`, followed by verifying checks passed in logs, and the status is working in UI.

