### PR TITLE
feat(cli): filter VM info by column values

### DIFF
--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -21,22 +22,32 @@ import (
 )
 
 const (
-	infoArgs         = 2
-	pauseArgs        = 2
-	defaultMem       = 512
-	redeployArgs     = 2
-	shutdownArgs     = 2
-	killArgs         = 2
-	connectArgs      = 4
-	disconnectArgs   = 3
-	startCaptureArgs = 4
-	startSubnetArgs  = 2
-	stopCaptureArgs  = 2
-	stopSubnetArgs   = 2
-	stopAllArgs      = 1
-	memSnapArgs      = 3
-	mountArgs        = 2
-	unmountArgs      = 2
+	infoArgs               = 2
+	pauseArgs              = 2
+	defaultMem             = 512
+	redeployArgs           = 2
+	shutdownArgs           = 2
+	killArgs               = 2
+	connectArgs            = 4
+	disconnectArgs         = 3
+	startCaptureArgs       = 4
+	startSubnetArgs        = 2
+	stopCaptureArgs        = 2
+	stopSubnetArgs         = 2
+	stopAllArgs            = 1
+	memSnapArgs            = 3
+	mountArgs              = 2
+	unmountArgs            = 2
+	vmInfoColumnHost       = "host"
+	vmInfoColumnName       = "name"
+	vmInfoColumnRunning    = "running"
+	vmInfoColumnDisk       = "disk"
+	vmInfoColumnInterfaces = "interfaces"
+	vmInfoColumnUptime     = "uptime"
+	vmInfoColumnMemory     = "memory"
+	vmInfoColumnVCPUs      = "vcpus"
+	vmInfoColumnOSType     = "ostype"
+	vmInfoColumnTaps       = "taps"
 )
 
 func vmArgsCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -170,6 +181,132 @@ func listVMsByLabel(expName string, labels []string) ([]mm.VM, error) {
 	return matchedVMs, nil
 }
 
+type vmInfoFilter struct {
+	column string
+	value  string
+}
+
+func parseVMInfoFilters(rawFilters []string) ([]vmInfoFilter, error) {
+	filters := make([]vmInfoFilter, 0, len(rawFilters))
+
+	for _, rawFilter := range rawFilters {
+		rawColumn, value, found := strings.Cut(rawFilter, "=")
+		if !found || strings.TrimSpace(rawColumn) == "" {
+			return nil, fmt.Errorf("invalid VM info filter %q: expected COLUMN=VALUE", rawFilter)
+		}
+
+		column := strings.ToLower(
+			strings.NewReplacer(" ", "", "-", "", "_", "").Replace(strings.TrimSpace(rawColumn)),
+		)
+		switch column {
+		case vmInfoColumnHost,
+			vmInfoColumnName,
+			vmInfoColumnRunning,
+			vmInfoColumnDisk,
+			vmInfoColumnInterfaces,
+			vmInfoColumnUptime,
+			vmInfoColumnMemory,
+			vmInfoColumnVCPUs,
+			vmInfoColumnOSType,
+			vmInfoColumnTaps:
+		case "ram":
+			column = vmInfoColumnMemory
+		case "cpus":
+			column = vmInfoColumnVCPUs
+		default:
+			return nil, fmt.Errorf("unknown VM info filter column %q", strings.TrimSpace(rawColumn))
+		}
+
+		filters = append(filters, vmInfoFilter{
+			column: column,
+			value:  strings.TrimSpace(value),
+		})
+	}
+
+	return filters, nil
+}
+
+func vmInfoColumnValue(vmInfo mm.VM, column string) string {
+	switch column {
+	case vmInfoColumnHost:
+		return vmInfo.Host
+	case vmInfoColumnName:
+		return vmInfo.Name
+	case vmInfoColumnRunning:
+		return strconv.FormatBool(vmInfo.Running)
+	case vmInfoColumnDisk:
+		return vmInfo.Disk
+	case vmInfoColumnInterfaces:
+		interfaces := make([]string, 0, len(vmInfo.Networks))
+		for idx, network := range vmInfo.Networks {
+			interfaces = append(interfaces, fmt.Sprintf("ID: %d, IP: %s, VLAN: %s", idx, vmInfo.IPv4[idx], network))
+		}
+
+		return strings.Join(interfaces, "\n")
+	case vmInfoColumnUptime:
+		if vmInfo.Running {
+			return (time.Duration(vmInfo.Uptime) * time.Second).String()
+		}
+
+		return ""
+	case vmInfoColumnMemory:
+		return strconv.Itoa(vmInfo.RAM)
+	case vmInfoColumnVCPUs:
+		return strconv.Itoa(vmInfo.CPUs)
+	case vmInfoColumnOSType:
+		return vmInfo.OSType
+	case vmInfoColumnTaps:
+		return strings.Join(vmInfo.Taps, ", ")
+	default:
+		panic(fmt.Sprintf("unsupported VM info column %q", column))
+	}
+}
+
+func vmInfoFilterMatches(vmInfo mm.VM, filter vmInfoFilter) bool {
+	value := vmInfoColumnValue(vmInfo, filter.column)
+	if strings.EqualFold(value, filter.value) {
+		return true
+	}
+
+	if filter.column != vmInfoColumnDisk || value == "" {
+		return false
+	}
+
+	filename := path.Base(value)
+	stem := strings.TrimSuffix(filename, path.Ext(filename))
+
+	return strings.EqualFold(filename, filter.value) || strings.EqualFold(stem, filter.value)
+}
+
+func filterVMInfo(vms []mm.VM, rawFilters []string) ([]mm.VM, error) {
+	filters, err := parseVMInfoFilters(rawFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(filters) == 0 {
+		return vms, nil
+	}
+
+	filtered := make([]mm.VM, 0, len(vms))
+
+	for _, vmInfo := range vms {
+		matches := true
+		for _, filter := range filters {
+			if !vmInfoFilterMatches(vmInfo, filter) {
+				matches = false
+				break
+			}
+		}
+
+		if matches {
+			filtered = append(filtered, vmInfo)
+		}
+	}
+
+	return filtered, nil
+}
+
 func vmTargetNamesForCommand(cmd *cobra.Command, args []string) (string, []string, error) {
 	if len(args) < 1 {
 		return "", nil, errors.New("must provide an experiment name")
@@ -250,7 +387,17 @@ func newVMInfoCmd() *cobra.Command {
 	desc := `Table of VM(s)
 
   Used to display a table of virtual machine(s) for a specific experiment;
-  VM name is optional, when included will display only that VM.`
+  VM name is optional, when included will display only that VM.
+
+  Filter the output by repeating --filter with a COLUMN=VALUE expression.
+  Multiple filters are combined with AND semantics. Column names and values
+  are case-insensitive. Supported columns are HOST, NAME, RUNNING, DISK,
+  INTERFACES, UPTIME, MEMORY, VCPUS, OS_TYPE, and TAPS. DISK values may be
+  full paths, filenames, or filenames without extensions. For example:
+
+    phenix vm info my-experiment --filter RUNNING=true
+    phenix vm info my-experiment --filter RUNNING=true --filter OS_TYPE=linux
+    phenix vm info my-experiment --filter DISK=jammy`
 
 	cmd := &cobra.Command{
 		Use:               "info <experiment name> [vm name]",
@@ -261,6 +408,11 @@ func newVMInfoCmd() *cobra.Command {
 			if len(args) < 1 {
 				return errors.New("must provide an experiment name")
 			}
+
+			var (
+				vms []mm.VM
+				err error
+			)
 
 			if cmd.Flags().Changed("label") {
 				flagLabels, err := cmd.Flags().GetStringArray("label")
@@ -273,50 +425,52 @@ func newVMInfoCmd() *cobra.Command {
 					return errors.New("must provide at least one VM label filter")
 				}
 
-				vms, err := listVMsByLabel(args[0], labels)
+				vms, err = listVMsByLabel(args[0], labels)
 				if err != nil {
 					err := util.HumanizeError(err, "Unable to get a filtered list of VMs")
 
 					return err.Humanized()
 				}
+			} else {
+				switch len(args) {
+				case 1:
+					vms, err = vm.List(args[0])
+					if err != nil {
+						err := util.HumanizeError(err, "Unable to get a list of VMs")
 
-				printer.PrintTableOfVMs(os.Stdout, MustGetBool(cmd.Flags(), "taps"), vms...)
+						return err.Humanized()
+					}
+				case infoArgs:
+					vmInfo, err := vm.Get(args[0], args[1])
+					if err != nil {
+						err := util.HumanizeError(
+							err,
+							"%s",
+							"Unable to get information for the "+args[1]+" VM",
+						)
 
-				return nil
+						return err.Humanized()
+					}
+
+					vms = []mm.VM{*vmInfo}
+				default:
+					return errors.New("invalid argument")
+				}
 			}
 
-			switch len(args) {
-			case 1:
-				vms, err := vm.List(args[0])
-				if err != nil {
-					err := util.HumanizeError(err, "Unable to get a list of VMs")
-
-					return err.Humanized()
-				}
-
-				printer.PrintTableOfVMs(os.Stdout, MustGetBool(cmd.Flags(), "taps"), vms...)
-			case infoArgs:
-				vm, err := vm.Get(args[0], args[1])
-				if err != nil {
-					err := util.HumanizeError(
-						err,
-						"%s",
-						"Unable to get information for the "+args[1]+" VM",
-					)
-
-					return err.Humanized()
-				}
-
-				printer.PrintTableOfVMs(os.Stdout, MustGetBool(cmd.Flags(), "taps"), *vm)
-			default:
-				return errors.New("invalid argument")
+			vms, err = filterVMInfo(vms, MustGetStringArray(cmd.Flags(), "filter"))
+			if err != nil {
+				return err
 			}
+
+			printer.PrintTableOfVMs(os.Stdout, MustGetBool(cmd.Flags(), "taps"), vms...)
 
 			return nil
 		},
 	}
 
 	addVMLabelFlag(cmd)
+	cmd.Flags().StringArrayP("filter", "f", nil, "Filter output by column value (COLUMN=VALUE); may be repeated")
 	cmd.Flags().BoolP("taps", "t", false, "Include tap interface names")
 
 	return cmd

--- a/src/go/cmd/vm_info_filter_test.go
+++ b/src/go/cmd/vm_info_filter_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"phenix/util/mm"
+)
+
+func TestParseVMInfoFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        string
+		wantColumn string
+		wantValue  string
+	}{
+		{name: "standard column", raw: "RUNNING=true", wantColumn: "running", wantValue: "true"},
+		{name: "column with spaces", raw: "OS TYPE=linux", wantColumn: "ostype", wantValue: "linux"},
+		{name: "column with underscore", raw: "OS_TYPE=linux", wantColumn: "ostype", wantValue: "linux"},
+		{name: "RAM alias", raw: "RAM=1024", wantColumn: "memory", wantValue: "1024"},
+		{name: "CPUs alias", raw: "CPUS=2", wantColumn: "vcpus", wantValue: "2"},
+		{name: "empty value", raw: "UPTIME=", wantColumn: "uptime", wantValue: ""},
+		{name: "value containing equals", raw: "DISK=disk=name", wantColumn: "disk", wantValue: "disk=name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseVMInfoFilters([]string{tt.raw})
+			if err != nil {
+				t.Fatalf("parseVMInfoFilters() error = %v", err)
+			}
+
+			if len(got) != 1 {
+				t.Fatalf("parseVMInfoFilters() returned %d filters, want 1", len(got))
+			}
+
+			if got[0].column != tt.wantColumn || got[0].value != tt.wantValue {
+				t.Fatalf("parseVMInfoFilters() = %+v, want column %q and value %q", got[0], tt.wantColumn, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestParseVMInfoFiltersRejectsInvalidFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "missing separator", raw: "RUNNING", want: "expected COLUMN=VALUE"},
+		{name: "missing column", raw: "=true", want: "expected COLUMN=VALUE"},
+		{name: "unknown column", raw: "STATE=running", want: "unknown VM info filter column"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseVMInfoFilters([]string{tt.raw})
+			if err == nil {
+				t.Fatal("parseVMInfoFilters() expected an error")
+			}
+
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("parseVMInfoFilters() error = %q, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterVMInfo(t *testing.T) {
+	t.Parallel()
+
+	vms := []mm.VM{
+		{
+			Name:    "server",
+			Host:    "node-1",
+			Running: true,
+			CPUs:    2,
+			RAM:     2048,
+			Disk:    "/phenix/images/jammy.qc2",
+			OSType:  "Linux",
+		},
+		{
+			Name:    "client",
+			Host:    "node-2",
+			Running: false,
+			CPUs:    1,
+			RAM:     1024,
+			OSType:  "Linux",
+		},
+		{
+			Name:    "router",
+			Host:    "node-1",
+			Running: true,
+			CPUs:    1,
+			RAM:     1024,
+			OSType:  "VyOS",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		filters []string
+		want    []string
+	}{
+		{name: "no filters", want: []string{"server", "client", "router"}},
+		{name: "running VMs", filters: []string{"RUNNING=true"}, want: []string{"server", "router"}},
+		{name: "case insensitive value", filters: []string{"OS_TYPE=linux"}, want: []string{"server", "client"}},
+		{name: "numeric value", filters: []string{"MEMORY=1024"}, want: []string{"client", "router"}},
+		{name: "disk full path", filters: []string{"DISK=/phenix/images/jammy.qc2"}, want: []string{"server"}},
+		{name: "disk filename", filters: []string{"DISK=jammy.qc2"}, want: []string{"server"}},
+		{name: "disk filename stem", filters: []string{"DISK=jammy"}, want: []string{"server"}},
+		{name: "disk filename case insensitive", filters: []string{"DISK=JAMMY.QC2"}, want: []string{"server"}},
+		{name: "multiple filters use AND", filters: []string{"HOST=node-1", "VCPUS=1"}, want: []string{"router"}},
+		{name: "no matches", filters: []string{"NAME=missing"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := filterVMInfo(vms, tt.filters)
+			if err != nil {
+				t.Fatalf("filterVMInfo() error = %v", err)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("filterVMInfo() returned %d VMs, want %d: %+v", len(got), len(tt.want), got)
+			}
+
+			for idx, vmInfo := range got {
+				if vmInfo.Name != tt.want[idx] {
+					t.Fatalf("filterVMInfo()[%d].Name = %q, want %q", idx, vmInfo.Name, tt.want[idx])
+				}
+			}
+		})
+	}
+}
+
+func TestVMInfoColumnValue(t *testing.T) {
+	t.Parallel()
+
+	vmInfo := mm.VM{
+		Host:     "node-1",
+		Name:     "server",
+		Running:  true,
+		Disk:     "server.qcow2",
+		Networks: []string{"users"},
+		IPv4:     []string{"10.0.0.2"},
+		Uptime:   90,
+		RAM:      2048,
+		CPUs:     2,
+		OSType:   "linux",
+		Taps:     []string{"mega_tap1", "mega_tap2"},
+	}
+
+	tests := []struct {
+		column string
+		want   string
+	}{
+		{column: "host", want: "node-1"},
+		{column: "name", want: "server"},
+		{column: "running", want: "true"},
+		{column: "disk", want: "server.qcow2"},
+		{column: "interfaces", want: "ID: 0, IP: 10.0.0.2, VLAN: users"},
+		{column: "uptime", want: "1m30s"},
+		{column: "memory", want: "2048"},
+		{column: "vcpus", want: "2"},
+		{column: "ostype", want: "linux"},
+		{column: "taps", want: "mega_tap1, mega_tap2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.column, func(t *testing.T) {
+			t.Parallel()
+
+			if got := vmInfoColumnValue(vmInfo, tt.column); got != tt.want {
+				t.Fatalf("vmInfoColumnValue(%q) = %q, want %q", tt.column, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVMInfoCommandFilterFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := newVMInfoCmd()
+	flag := cmd.Flags().Lookup("filter")
+	if flag == nil {
+		t.Fatal("newVMInfoCmd() does not define --filter")
+	}
+
+	if flag.Shorthand != "f" {
+		t.Fatalf("--filter shorthand = %q, want %q", flag.Shorthand, "f")
+	}
+}


### PR DESCRIPTION
## Description

Add repeatable `COLUMN=VALUE` filters to `phenix vm info` so users can restrict output by displayed VM fields. Filters are case-insensitive and combine with AND semantics. `DISK` filters accept full paths, filenames, or extensionless filename stems.

### Example commands

```shell
phenix vm info my-experiment --filter RUNNING=true
phenix vm info my-experiment --filter RUNNING=true --filter OS_TYPE=linux
phenix vm info my-experiment --filter DISK=jammy
```

### Example output

```shell
$ phenix vm info helloworld -f DISK=jammy.qc2
+--------+-------------+---------+--------------------------+------------------------------------------+--------+--------+-------+---------+
|  HOST  |    NAME     | RUNNING |           DISK           |                INTERFACES                | UPTIME | MEMORY | VCPUS | OS TYPE |
+--------+-------------+---------+--------------------------+------------------------------------------+--------+--------+-------+---------+
| hst001 | test1       | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 192.168.1.10, VLAN: SW1 (101) | 29s    |   2048 |     2 | linux   |
| hst001 | test2       | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 192.168.1.11, VLAN: SW1 (101) | 29s    |   2048 |     1 | linux   |
| hst001 | unlabeled   | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 192.168.2.12, VLAN: SW2 (102) | 29s    |   2048 |     1 | linux   |
| hst001 | tap-example | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 172.16.0.33, VLAN: MGMT (103) | 29s    |   2048 |     1 | linux   |
+--------+-------------+---------+--------------------------+------------------------------------------+--------+--------+-------+---------+

$ phenix vm info helloworld -f cpus=2
+--------+----------+---------+-----------------------------+------------------------------------------+--------+--------+-------+---------+
|  HOST  |   NAME   | RUNNING |            DISK             |                INTERFACES                | UPTIME | MEMORY | VCPUS | OS TYPE |
+--------+----------+---------+-----------------------------+------------------------------------------+--------+--------+-------+---------+
| hst001 | test1    | true    | /phenix/images/jammy.qc2    | ID: 0, IP: 192.168.1.10, VLAN: SW1 (101) | 49s    |   2048 |     2 | linux   |
| hst001 | looploop | true    | /phenix/images/looploop.qc2 | ID: 0, IP: 192.168.1.31, VLAN: SW1 (101) | 48s    |   4096 |     2 | linux   |
|        |          |         |                             | ID: 1, IP: 172.16.0.55, VLAN: MGMT (103) |        |        |       |         |
+--------+----------+---------+-----------------------------+------------------------------------------+--------+--------+-------+---------+
```

## Related Issue

Closes #6

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Tested on a phenix deployment with a running experiment.
