### PR TITLE
feat(cli): add command aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.0.0]
 
 ### Added
+- **CLI Command Aliases**: Added `exp del`, `exp trig`, `exp res`, `exp rec`, `image del`, `config del`, and `vm res`.
 - **Centralized Logging Architecture**: Implemented a unified logging system where phēnix core aggregates logs from internal services and external apps.
 - **Dynamic Configuration**: Integrated `viper` with `fsnotify` to allow hot-swapping of configuration settings (e.g., log levels) without restarting services.
 - **Log Rotation**: Configurable log rotation settings (`max-size`, `max-backups`, `max-age`) for the persistent system log.

--- a/src/go/cmd/aliases.go
+++ b/src/go/cmd/aliases.go
@@ -1,0 +1,6 @@
+package cmd
+
+const (
+	deleteAlias  = "del"
+	restartAlias = "res"
+)

--- a/src/go/cmd/command_aliases_test.go
+++ b/src/go/cmd/command_aliases_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCommandAliases(t *testing.T) {
+	tests := []struct {
+		name        string
+		parent      *cobra.Command
+		command     *cobra.Command
+		alias       string
+		commandName string
+	}{
+		{
+			name:        "image delete",
+			parent:      newImageCmd(),
+			command:     newImageDeleteCmd(),
+			alias:       deleteAlias,
+			commandName: "delete",
+		},
+		{
+			name:        "config delete",
+			parent:      newConfigCmd(),
+			command:     newConfigDeleteCmd(),
+			alias:       deleteAlias,
+			commandName: "delete",
+		},
+		{
+			name:        "vm restart",
+			parent:      newVMCmd(),
+			command:     newVMRestartCmd(),
+			alias:       restartAlias,
+			commandName: "restart",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := &cobra.Command{Use: "phenix"}
+			test.parent.AddCommand(test.command)
+			root.AddCommand(test.parent)
+
+			command, _, err := root.Find([]string{test.parent.Name(), test.alias})
+			if err != nil {
+				t.Fatalf("expected alias to resolve: %v", err)
+			}
+			if command.Name() != test.commandName {
+				t.Fatalf("expected alias to resolve to %q, got %q", test.commandName, command.Name())
+			}
+		})
+	}
+}

--- a/src/go/cmd/config.go
+++ b/src/go/cmd/config.go
@@ -422,10 +422,11 @@ func newConfigDeleteCmd() *cobra.Command {
 	`
 
 	cmd := &cobra.Command{
-		Use:   "delete <kind/name> ...",
-		Short: "Delete a configuration(s)",
-		Long:  desc,
-		Args:  configKindArgsValidator(true, false),
+		Use:     "delete <kind/name> ...",
+		Aliases: []string{deleteAlias},
+		Short:   "Delete a configuration(s)",
+		Long:    desc,
+		Args:    configKindArgsValidator(true, false),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			for _, c := range args {
 				err := config.Delete(c)

--- a/src/go/cmd/experiment.go
+++ b/src/go/cmd/experiment.go
@@ -314,6 +314,7 @@ func newExperimentDeleteCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "delete <experiment name>",
+		Aliases:           []string{deleteAlias},
 		Short:             "Delete an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
@@ -663,6 +664,7 @@ func newExperimentRestartCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "restart <experiment name>",
+		Aliases:           []string{restartAlias},
 		Short:             "Restart an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
@@ -769,6 +771,7 @@ func newExperimentReconfigureCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "reconfigure <experiment name>",
+		Aliases:           []string{"rec"},
 		Short:             "Reconfigure an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
@@ -846,9 +849,10 @@ func newExperimentTriggerRunningCmd() *cobra.Command {
 	be run.`
 
 	cmd := &cobra.Command{
-		Use:   "trigger-running <experiment name> [<app name> ...]",
-		Short: "Trigger running stage for app(s) in experiment",
-		Long:  desc,
+		Use:     "trigger-running <experiment name> [<app name> ...]",
+		Aliases: []string{"trig"},
+		Short:   "Trigger running stage for app(s) in experiment",
+		Long:    desc,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return expNameCompletion(true)(cmd, args, toComplete)

--- a/src/go/cmd/experiment_cmd_test.go
+++ b/src/go/cmd/experiment_cmd_test.go
@@ -98,6 +98,36 @@ func TestExperimentCommandsShowUsageForMissingArguments(t *testing.T) {
 	}
 }
 
+func TestExperimentCommandAliases(t *testing.T) {
+	tests := []struct {
+		alias      string
+		command    string
+		newCommand func() *cobra.Command
+	}{
+		{alias: deleteAlias, command: "delete", newCommand: newExperimentDeleteCmd},
+		{alias: "trig", command: "trigger-running", newCommand: newExperimentTriggerRunningCmd},
+		{alias: restartAlias, command: "restart", newCommand: newExperimentRestartCmd},
+		{alias: "rec", command: "reconfigure", newCommand: newExperimentReconfigureCmd},
+	}
+
+	for _, test := range tests {
+		t.Run(test.alias, func(t *testing.T) {
+			root := &cobra.Command{Use: "phenix"}
+			experimentCmd := newExperimentCmd()
+			experimentCmd.AddCommand(test.newCommand())
+			root.AddCommand(experimentCmd)
+
+			command, _, err := root.Find([]string{"exp", test.alias})
+			if err != nil {
+				t.Fatalf("expected alias to resolve: %v", err)
+			}
+			if command.Name() != test.command {
+				t.Fatalf("expected alias to resolve to %q, got %q", test.command, command.Name())
+			}
+		})
+	}
+}
+
 func TestExperimentScheduleUsageDescribesArgumentOrder(t *testing.T) {
 	cmd := newExperimentScheduleCmd()
 

--- a/src/go/cmd/image.go
+++ b/src/go/cmd/image.go
@@ -378,8 +378,9 @@ func newImageBuildCmd() *cobra.Command {
 
 func newImageDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <configuration name>",
-		Short: "Delete an existing image configuration",
+		Use:     "delete <configuration name>",
+		Aliases: []string{deleteAlias},
+		Short:   "Delete an existing image configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 

--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -355,6 +355,7 @@ func newVMResumeCmd() *cobra.Command {
 func newVMRestartCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "restart <experiment name> [vm name]",
+		Aliases:           []string{restartAlias},
 		Short:             "Restart running, paused, or powered off VM(s) for a specific experiment",
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# feat(cli): add command aliases

## Description
Adds concise aliases for common experiment, image, config, and VM commands.

Added: `exp del`, `exp trig`, `exp res`, `exp rec`, `image del`, `config del`, and `vm res`.

## Related Issue
None.

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Documentation is not required; Cobra exposes aliases in generated help.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Validated with targeted golangci-lint and go test ./cmd.