### PR TITLE
fix(ui): ensure killed VMs don't reappear

### DIFF
--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -122,9 +122,15 @@ func List(expName string) ([]mm.VM, error) { //nolint:funlen // complex logic
 			}
 		}
 
-		if node.External() {
+		details, exists := running[vm.Name]
+		if exp.Running() && !exp.DryRun() && !node.External() && !dnb && !exists {
+			continue
+		}
+
+		switch {
+		case node.External():
 			vm.State = "EXTERNAL"
-		} else if details, ok := running[vm.Name]; ok {
+		case exists:
 			vm.Host = details.Host
 			vm.State = details.State
 			vm.Running = details.Running
@@ -166,7 +172,7 @@ func List(expName string) ([]mm.VM, error) { //nolint:funlen // complex logic
 					vm.IPv4[i] = "n/a"
 				}
 			}
-		} else {
+		default:
 			vm.Host = exp.Spec.Schedules()[vm.Name]
 		}
 

--- a/src/go/api/vm/vm_test.go
+++ b/src/go/api/vm/vm_test.go
@@ -9,12 +9,23 @@ import (
 	"phenix/api/vm"
 	"phenix/store"
 	"phenix/types"
+	"phenix/util/mm"
 )
+
+type listMM struct {
+	mm.MM
+
+	vms mm.VMs
+}
+
+func (m listMM) GetVMInfo(...mm.Option) mm.VMs {
+	return m.vms
+}
 
 // getTestExperiment builds a store mock backing a minimal experiment with one
 // topology node and one scenario app that targets the node with metadata, and
 // makes it the phenix default store for the duration of the test.
-func getTestExperiment(t *testing.T, vmName string, appMetadata map[string]any) {
+func getTestExperiment(t *testing.T, vmName string, appMetadata map[string]any, startTime string) {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
@@ -76,6 +87,10 @@ func getTestExperiment(t *testing.T, vmName string, appMetadata map[string]any) 
 		},
 	}
 
+	if startTime != "" {
+		c.Status = map[string]any{"startTime": startTime}
+	}
+
 	m := store.NewMockStore(ctrl)
 	m.EXPECT().Get(gomock.Any()).DoAndReturn(func(cfg *store.Config) error {
 		*cfg = c
@@ -95,7 +110,7 @@ func getTestExperiment(t *testing.T, vmName string, appMetadata map[string]any) 
 func TestGetIncludesAppMetadata(t *testing.T) {
 	metadata := map[string]any{"key": "value"}
 
-	getTestExperiment(t, "test-vm", metadata)
+	getTestExperiment(t, "test-vm", metadata, "")
 
 	got, err := vm.Get("test-experiment", "test-vm")
 	if err != nil {
@@ -114,6 +129,53 @@ func TestGetIncludesAppMetadata(t *testing.T) {
 
 	if !reflect.DeepEqual(appMetadataMap, metadata) {
 		t.Fatalf("expected app metadata %v, got %v", metadata, appMetadataMap)
+	}
+}
+
+func TestListExcludesKilledVMsFromRunningExperiment(t *testing.T) {
+	tests := []struct {
+		name      string
+		startTime string
+		vms       mm.VMs
+		want      int
+	}{
+		{
+			name:      "running VM remains listed",
+			startTime: "2026-08-26T00:00:00Z",
+			vms:       mm.VMs{{Name: "test-vm", Running: true}},
+			want:      1,
+		},
+		{
+			name:      "killed VM is excluded",
+			startTime: "2026-08-26T00:00:00Z",
+			vms:       nil,
+			want:      0,
+		},
+		{
+			name:      "dry-run VM remains listed",
+			startTime: "2026-08-26T00:00:00Z-DRYRUN",
+			vms:       nil,
+			want:      1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			getTestExperiment(t, "test-vm", nil, test.startTime)
+
+			originalMM := mm.DefaultMM
+			t.Cleanup(func() { mm.DefaultMM = originalMM }) //nolint:reassign // restore test double
+			mm.DefaultMM = listMM{vms: test.vms}            //nolint:reassign // install test double
+
+			got, err := vm.List("test-experiment")
+			if err != nil {
+				t.Fatalf("vm.List returned error: %v", err)
+			}
+
+			if len(got) != test.want {
+				t.Fatalf("vm.List returned %d VMs, want %d: %#v", len(got), test.want, got)
+			}
+		})
 	}
 }
 

--- a/src/go/web/broker/client.go
+++ b/src/go/web/broker/client.go
@@ -448,6 +448,8 @@ func (c *Client) read() { //nolint:maintidx // complex logic
 				allowed.SortBy(sort, asc)
 			}
 
+			totalBeforePaging := len(allowed)
+
 			if page != 0 && size != 0 {
 				allowed = allowed.Paginate(page, size)
 			}
@@ -463,7 +465,7 @@ func (c *Client) read() { //nolint:maintidx // complex logic
 			c.vmMu.Unlock()
 
 			resp := &proto.VMList{
-				Total: uint32(len(allowed)), //nolint:gosec // integer overflow conversion int -> uint32
+				Total: uint32(totalBeforePaging), //nolint:gosec // integer overflow conversion int -> uint32
 				Vms:   make([]*proto.VM, len(allowed)),
 			}
 			for i, v := range allowed {

--- a/src/js/src/views/experiment/RunningExperiment.vue
+++ b/src/js/src/views/experiment/RunningExperiment.vue
@@ -1778,9 +1778,9 @@
             }
 
             this.experiment.vms = [...msg.result.vms];
+            this.table.total = msg.result.total;
 
             if (this.search.filter) {
-              this.table.total = msg.result.total;
               // Only add successful searches to the search history
               if (this.table.total > 0) {
                 if (this.searchHistory > this.searchHistoryLength) {
@@ -1789,8 +1789,6 @@
                 this.searchHistory.push(this.search.filter.trim());
                 this.searchHistory = this.getUniqueItems(this.searchHistory);
               }
-            } else {
-              this.table.total = this.experiment.vm_count;
             }
 
             this.isWaiting = false;


### PR DESCRIPTION
## Description
Fixes running experiment VM refreshes so killed VMs stay removed from list of VMs in the experiment UI.

## Related Issue
Fixes sandialabs/sceptre-phenix#28.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Tests: `go test ./api/vm ./web/broker ./web`, `npm test`, `npm run build`.

Tested on a range node. Killed a VM. Verified it didn't reappear in list of VMs.