### PR TITLE
docs: add scoped AGENTS.md guidance

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,9 +58,9 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
 
 ### Submitting Code
 
-1. **Create a Branch**: Create a new branch (on your fork of the repository) for your feature or bug fix using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) notation. The branch name should follow this format:
+1. **Create a Branch**: Create a new branch (on your fork of the repository) for your feature or bug fix using a [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) type. Branch names must not contain `/` and should follow this format:
     ```bash
-    type/description
+    type-description
     ```
     Where `type` can be one of the following:
     - `feat`: A new feature
@@ -73,7 +73,7 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
 
     Example:
     ```bash
-    git checkout -b feat/add-user-authentication
+    git checkout -b feat-add-user-authentication
     ```
 
 2. **Make Your Changes**: Implement your changes. Please include unit tests for any new logic or features.
@@ -129,7 +129,7 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
 
     Example:
     ```bash
-    git push origin feat/add-user-authentication --force
+    git push origin feat-add-user-authentication --force
     ```
 
 6. **Open a Pull Request**: Go to the original repository and open a [pull request](https://github.com/sandialabs/sceptre-phenix/pulls). Provide a clear description of your changes and reference any related issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,157 @@
+# AGENTS.md
+
+## Project and Instruction Scope
+
+phēnix is a Go/Cobra and Vue 3 platform for defining, deploying, and managing
+cyber experiments on minimega. Major areas are `src/go/` (core, CLI, API, and
+server), `src/js/` (web UI), `examples/` (Go and Python apps), and container
+assets in `docker/` and `podman/`.
+
+Root rules apply everywhere. Before changing a scoped area, read its closer
+instructions:
+
+| Trigger | Required instructions |
+|---|---|
+| Any Go core, CLI, API, schema, store, RBAC, protobuf, minimega, or server work | [`src/go/AGENTS.md`](src/go/AGENTS.md) |
+| Any Vue, JavaScript/TypeScript, Vite, Vitest, UI auth, or Playwright work | [`src/js/AGENTS.md`](src/js/AGENTS.md) |
+| Any Go or Python example app work | [`examples/AGENTS.md`](examples/AGENTS.md) |
+
+The closest `AGENTS.md` adds area-specific rules; this file remains binding.
+
+## phēnix Domain Reference
+
+Before answering usage questions or changing CLI commands, REST routes,
+configuration resources, experiments, VMs, images, VLANs, settings, apps,
+SCORCH, minimega integration, or cyber-range workflows, read
+[`skills/phenix/SKILL.md`](skills/phenix/SKILL.md). Use code as final authority
+when guidance differs, and update the skill when behavior changes.
+
+## Architecture
+
+- `src/go/main.go` starts commands from `src/go/cmd/`.
+- `src/go/api/` implements domain operations; `src/go/types/` owns versioned
+  config models and schemas.
+- `src/go/app/` runs apps; `scheduler/` assigns VMs; `store/` abstracts BoltDB
+  and etcd; `web/` serves REST, websockets, RBAC, and the built UI.
+- `src/js/src/views/` contains pages, `components/` reusable UI, and `utils/`
+  shared helpers. `router.js`, `store.js`, and `main.js` wire the app.
+- The Vite server proxies `/api/v1`, `/version`, and `/features` to
+  `localhost:3000`. Root builds copy `src/js/dist/` into `src/go/web/public/`.
+
+## Essential Runtime Contracts
+
+- phēnix apps receive experiment JSON on stdin and one lifecycle argument:
+  `configure`, `pre-start`, `post-start`, `running`, or `cleanup`.
+- Apps must emit only valid experiment JSON on stdout and single-line structured
+  JSON logs on stderr. Python apps use `phenix_apps.common.logger`; Go apps use
+  `log/slog` with a JSON stderr handler.
+- Core logging uses `phenix/util/plog`: call `plog.Debug`, `Info`, `Warn`, or
+  `Error` with the appropriate `LogType`, message, and structured key/value
+  fields. The core routes records to console, system log, and web UI.
+- API auth uses `X-Phenix-Auth-Token`, not `Authorization`.
+- Runtime precedence is CLI flags, config file, environment, then defaults.
+- Never delete a live `config.yaml`; use `phenix settings unset` so its watcher
+  remains active.
+
+## Setup and Common Commands
+
+Requirements: Go 1.24+, Node.js 24+, Python 3.12+, `protoc` 3.12+, npm, and
+Docker for full deployments and image builds.
+
+| Purpose | Command |
+|---|---|
+| Inspect targets | `make help` or `make help-all` |
+| Install development tools | `make install-dev` |
+| Install with another Python | `SYSTEM_PYTHON=/path/to/python3.12 make install-dev` |
+| Generate mocks, protobufs, and RBAC | `make generate` |
+| Format / fixing lint for Go/examples | `make format` / `make lint` |
+| Generate, then non-fixing lint | `make check` |
+| Go core and example tests | `make test` |
+| Build UI and `bin/phenix` | `make build` |
+| Build UI only | `make ui` |
+| Build container / Debian package | `make docker` / `make deb` |
+
+Use `npm ci`, never dependency-updating installs, for locked frontend
+dependencies. The root `make check` runs generation and may modify generated
+files. The root `make test` excludes Vitest and Playwright.
+
+Docker is the normal deployment. For automation, omit TTY flags:
+
+```bash
+docker exec phenix phenix experiment list
+```
+
+## Change Impact and Compatibility
+
+When changing a capability, inspect every applicable surface:
+
+| Change | Also inspect or update |
+|---|---|
+| CLI, REST, or UI capability | Implement parity in the other two when applicable and feasible; document gaps |
+| Config field or version | Versioned structs, interfaces, schemas, examples, API output, skill, and docs |
+| REST route | Domain API, route table, RBAC, OpenAPI, UI client, and tests |
+| Store interface | Implementations, mock generation, callers, and tests |
+| Protobuf | `.proto`, generated files, consumers, and tests |
+| RBAC role or policy | Policy generation, migrations, authorization surfaces, and migration tests |
+| minimega command | minimega API/source behavior and focused tests |
+
+Preserve v1/v2 config upgrades, persisted BoltDB/etcd data, RBAC migrations, and
+public API compatibility unless a breaking change is deliberate and documented.
+Keep CLI, REST, websocket, and UI authorization consistent.
+
+## Validation
+
+Run the narrowest existing test, build, or lint command covering the change,
+then the broader affected-area check from the scoped instructions. Add focused
+tests for behavior changes. Report checks you cannot run; do not silently skip
+requirements such as Docker, minimega, VM images, root privileges, or a running
+backend. Review generated diffs before submission.
+
+## Documentation and References
+
+| Need | Reference |
+|---|---|
+| Build, install, logging, config | `README.md` |
+| App development | `examples/README.md`, `examples/TUTORIAL.md` |
+| Config interfaces and fields | `src/go/types/interfaces/`, `src/go/types/version/` |
+| YAML config schemas | `src/go/types/version/schemas/{v0,v1,v2}.yaml` |
+| CLI and REST implementation | `src/go/cmd/`, `src/go/web/server.go` |
+| Internet-hosted narrative docs | [phenix.sceptre.dev](https://phenix.sceptre.dev/latest/) |
+| minimega commands and behavior | [API docs](https://sandia-minimega.github.io/), [source](https://github.com/sandia-minimega/minimega) |
+| Official apps and SCORCH components | [`sceptre-phenix-apps`](https://github.com/sandialabs/sceptre-phenix-apps) |
+| Image configs, overlays, scripts | [`sceptre-phenix-images`](https://github.com/sandialabs/sceptre-phenix-images) |
+| Source for phenix.sceptre.dev | [`sceptre-phenix-docs`](https://github.com/sandialabs/sceptre-phenix-docs) |
+| Reusable topologies | [`sceptre-phenix-topologies`](https://github.com/sandialabs/sceptre-phenix-topologies) |
+
+Consult minimega documentation and source whenever code constructs commands or
+interacts with minimega. Use companion repositories when local code lacks app,
+image, documentation, or topology details.
+
+## Change Management
+
+- Follow `.github/CONTRIBUTING.md`; use Conventional Commit messages.
+- Branch names use a Conventional Commit type and no `/`, for example
+  `feat-add-user-authentication`.
+- Use rebase workflow and one commit per logical feature; PRs normally contain
+  one commit. Squash work-in-progress commits and update the message.
+- Update `CHANGELOG.md` for code or behavior changes and `CODEOWNERS` for new
+  areas or ownership changes.
+- New user-facing features need a minimal README example and documentation in
+  [`sceptre-phenix-docs`](https://github.com/sandialabs/sceptre-phenix-docs).
+  Existing changes may also require docs; cross-link both pull requests.
+- Keep API docs, schemas, examples, and the phēnix skill aligned with behavior.
+- Use issue and PR templates under `.github/`. Keep PR descriptions concise:
+  purpose, relevant changes, related issue, and reviewer context only.
+
+## CI and Release Safety
+
+GitHub Actions is path-scoped: `ci.yml` generates, lints, and tests Go;
+`frontend.yml` runs Vitest, builds UI/backend, and runs Playwright smoke tests;
+`examples.yml` checks Go/Python examples; `packages.yml` builds Docker, Debian,
+and Podman outputs. Update affected path filters, inputs, generated artifacts,
+tool versions, and local-equivalent commands together. Preserve least-privilege
+permissions, supported action versions, lockfile caches, and shared version
+values.
+
+Do not publish artifacts, push images, or create releases under any
+circumstances.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,37 @@
+# Example App Instructions
+
+Read root [`AGENTS.md`](../AGENTS.md) first, especially its app lifecycle and
+stdout/stderr contracts. These rules apply under `examples/`.
+
+## Scope
+
+`go/` and `python/` are runnable reference implementations of phēnix apps.
+Changes must remain clear examples of the production app contract, not introduce
+example-only behavior that contradicts the platform.
+
+## Setup and Commands
+
+Python requires 3.12+. `make -C examples install-dev` creates `examples/.venv`;
+set `SYSTEM_PYTHON` when the default interpreter is older.
+
+| Purpose | Command |
+|---|---|
+| Build and test Go example | `make -C examples example-go` |
+| Compile and test Python example | `make -C examples example-python` |
+| Test both | `make -C examples test` |
+| Non-fixing checks | `make -C examples check` |
+| Format | `make -C examples format` |
+| Run with sample input | `make -C examples run-go` / `run-python` |
+
+## Conventions and Tests
+
+- Go uses `gofmt`, `golangci-lint`, `log/slog`, and JSON logs on stderr.
+- Python uses Black, Flake8, and `phenix_apps.common.logger`.
+- Keep stdout exclusively for the resulting experiment JSON.
+- Go tests use the subprocess pattern for arguments, streams, and exit codes.
+- Python tests mock stdin and capture structured stderr.
+- Update `README.md` and `TUTORIAL.md` when example behavior or workflows
+  change.
+
+`.github/workflows/examples.yml` builds/tests both examples with Go 1.24 and
+Python 3.12. Keep workflow versions, dependencies, and Make targets aligned.

--- a/skills/phenix/SKILL.md
+++ b/skills/phenix/SKILL.md
@@ -432,65 +432,10 @@ for the authoritative reference.
 
 ## Contributing
 
-When making a code/behavior change to this repo (not just this skill doc):
-
-- **Update `CHANGELOG.md`**: add an entry describing the change under the
-  top-most version section (or a new `[Unreleased]` section if the top
-  entry has already been released), following the existing
-  `### Added` / `### Changed` / `### Fixed` grouping style already used in
-  the file.
-- **New features need a README example**: if the change adds a new feature
-  (CLI flag, subcommand, API route, config option, app, etc.), add a short
-  bullet to the relevant `README.md` section showing a minimal example of
-  using it (e.g. a one-line command or snippet), not just a prose
-  description.
-- See `.github/CONTRIBUTING.md` for branch naming (Conventional Commits,
-  `type/description`, no other slashes), commit message format, and PR
-  process.
+Follow [`AGENTS.md`](../../AGENTS.md#change-management) for repository change,
+documentation, branch, commit, and pull request requirements.
 
 ## References
 
-- Project README: `README.md` (build/install, logging & configuration architecture)
-- Example apps and dev workflow: `examples/README.md`, `examples/TUTORIAL.md`
-- Topology/Scenario/Experiment Go interfaces: `src/go/types/interfaces/{topology,scenario,experiment}.go`
-- v1/v2 struct field definitions (YAML/JSON keys): `src/go/types/version/v1/*.go`, `src/go/types/version/v2/*.go`
-- Full JSON Schema for topology node shape (enums for type/os_type/proto/etc.):
-  `src/go/web/public/grapheditor/utils/schemas/topo_schema.json`
-- CLI command implementations: `src/go/cmd/*.go`
-- Web API route table: `src/go/web/server.go`
-- Online docs: [Configuration Files](https://phenix.sceptre.dev/latest/configuration/),
-  [Apps](https://phenix.sceptre.dev/latest/apps/),
-  [Settings & Configuration](https://phenix.sceptre.dev/latest/settings/)
-
-### Related repositories
-
-phenix's ecosystem is split across several companion GitHub repos
-(`sandialabs/sceptre-phenix-*`). Consult these when the current repo doesn't
-have the answer:
-
-- **[`sceptre-phenix-apps`](https://github.com/sandialabs/sceptre-phenix-apps)**
-  — source for the official (non-default) phenix apps and SCORCH components
-  (e.g. `caldera`, `scale`, `wireguard`, `otsim`, `helics`, `packetbeat`,
-  `elasticsearch`). Reference this when writing/debugging a scenario `apps`
-  entry for one of these apps, when an app's metadata schema isn't documented
-  in this skill, or when authoring a new custom app (it also documents the
-  phenix "App Contract": read stage arg + experiment JSON on stdin, write
-  updated experiment JSON to stdout, structured JSON logs to stderr).
-- **[`sceptre-phenix-images`](https://github.com/sandialabs/sceptre-phenix-images)**
-  — configuration files, overlays, and scripts used by `phenix image` (a
-  wrapper around [vmdb2](https://vmdb2.liw.fi/)) to build Debian-based qcow2
-  VM disk images. Reference this when creating/customizing an `Image` config,
-  looking for an existing overlay/script to reuse with `phenix image create -O/-T`,
-  or debugging an image build failure.
-- **[`sceptre-phenix-docs`](https://github.com/sandialabs/sceptre-phenix-docs)**
-  — source for the official documentation site at
-  [phenix.sceptre.dev](https://phenix.sceptre.dev) (MkDocs + Material).
-  Reference this (or fetch the live site) for narrative/how-to documentation
-  beyond what's summarized in this skill — e.g. full config reference pages,
-  state-of-health, VM management, or settings docs.
-- **[`sceptre-phenix-topologies`](https://github.com/sandialabs/sceptre-phenix-topologies)**
-  — a library of ready-to-use example Topology configs (uses Git LFS for disk
-  images), including a detailed "soap" example and a minimal "helloworld".
-  Reference this when the user wants a starting-point topology to copy/adapt
-  instead of writing one from scratch, or wants to see a real-world example
-  of a particular topology feature (routers, NAT, delayed starts, etc.).
+See [`AGENTS.md`](../../AGENTS.md#documentation-and-other-references) for the
+repository documentation map and companion phēnix repositories.

--- a/src/go/AGENTS.md
+++ b/src/go/AGENTS.md
@@ -1,0 +1,61 @@
+# Go Core Instructions
+
+Read root [`AGENTS.md`](../../AGENTS.md) first. These rules apply to all work
+under `src/go/`.
+
+## Source Map
+
+- `cmd/`: Cobra commands; `api/`: domain operations; `types/`: versioned
+  resources and schemas.
+- `app/`: built-in and user app execution; `scheduler/`: VM placement.
+- `store/`: BoltDB/etcd abstraction; `web/`: REST, websocket, RBAC, and UI
+  serving; `util/mm/`: minimega integration.
+
+## Commands
+
+Run from `src/go/`:
+
+| Purpose | Command |
+|---|---|
+| Focused tests | `go test -race ./path/to/package/...` |
+| All Go tests | `go test -race ./...` or `make test` |
+| Non-fixing lint | `make check` |
+| Format / fixing lint | `make format` / `make lint` |
+| Generate all outputs | `make generate` |
+| Build Linux binary | `make phenix` |
+
+Use targeted package tests first. `make check` here does not generate files;
+the root target does.
+
+## Generation and Compatibility
+
+- Run `make generate` after protobuf, store-interface, or RBAC policy changes.
+- Never manually edit `store/mock.go`, `web/proto/*.pb.go`, or
+  `web/rbac/known_policy.go`; include regenerated outputs in the change.
+- Preserve bundled third-party assets under `web/public/` unless explicitly
+  upgrading or replacing them.
+- Config changes must keep versioned structs, interfaces, YAML/JSON tags,
+  OpenAPI schemas, upgrades, examples, and API output aligned.
+- Preserve old config upgrades and persisted BoltDB/etcd compatibility.
+- RBAC changes require generated policy, migrations when needed, and migration
+  tests. Keep CLI, REST, websocket, and UI authorization equivalent.
+- API route changes require domain behavior, `web/server.go`, RBAC,
+  `web/public/docs/openapi.yml`, consumers, and tests.
+
+## Go Conventions
+
+- Follow `.golangci.yml` and `gofmt`; Go and Makefiles use tabs.
+- Return operational and validation errors using existing patterns; do not
+  silently recover.
+- Use `phenix/util/plog` for core logs with the correct `LogType` and structured
+  key/value fields.
+- Consult [minimega API docs](https://sandia-minimega.github.io/) and
+  [source](https://github.com/sandia-minimega/minimega) before changing code
+  that constructs commands or depends on minimega behavior.
+
+## CI
+
+`.github/workflows/ci.yml` generates artifacts, runs `make check`, and executes
+race-enabled tests. Go changes can also trigger `.github/workflows/frontend.yml`
+because browser smoke tests build and run the backend. Keep workflow paths,
+Go/tool versions, and local commands aligned.

--- a/src/js/AGENTS.md
+++ b/src/js/AGENTS.md
@@ -1,0 +1,67 @@
+# Frontend Instructions
+
+Read root [`AGENTS.md`](../../AGENTS.md) first. This UI uses Vue 3. These rules
+apply to Vue, JavaScript/TypeScript, Vite, Vitest, and Playwright work under
+`src/js/`.
+
+## Architecture
+
+- `src/views/`: route-level pages; `src/components/`: small reusable UI.
+- `src/utils/`: shared helpers; `router.js`: routes and guards; `store.js`:
+  Pinia state; `main.js`: application setup.
+- Vite proxies `/api/v1`, `/version`, and `/features` to `localhost:3000`.
+- `dist/` is generated output and is copied into `src/go/web/public/`; do not
+  treat it as source.
+
+## Setup and Commands
+
+Use Node.js 24 and locked installs:
+
+```bash
+nvm use
+npm ci
+```
+
+| Purpose | Command |
+|---|---|
+| Development server | `npm run dev` |
+| Focused Vitest | `npm test -- test/rbac.test.js` |
+| All Vitest | `npm test` |
+| Production build | `npm run build` |
+| Format, then review diff | `npm run format` |
+
+The development server needs a backend on `localhost:3000`.
+
+## UI Conventions
+
+- Follow two-space indentation and Prettier.
+- Use existing Pinia, router, Axios, Buefy, and component patterns.
+- Import Font Awesome icons individually in `src/main.js`; never import the
+  entire icon set.
+- Authentication is selected at build time with
+  `VITE_AUTH=enabled|disabled|proxy`. Validate the affected mode and keep UI,
+  REST, websocket, and RBAC behavior aligned.
+
+## Browser Tests
+
+Playwright requires a running `phenix ui`; default URL is
+`http://127.0.0.1:3000`, override with `E2E_BASE_URL`:
+
+```bash
+cd e2e
+npm ci
+npx playwright install --with-deps chromium
+npx playwright test
+```
+
+Default smoke tests need only a server. Lifecycle tests additionally need
+minimega, VM images, and a topology (`E2E_LIFECYCLE=1`). Auth suites require a
+matching `VITE_AUTH` build and signing key. See `e2e/README.md`; report missing
+prerequisites instead of silently skipping checks.
+
+## CI
+
+`.github/workflows/frontend.yml` runs Vitest and builds the UI, then builds and
+starts a real backend for Playwright smoke tests. Keep Node versions, npm cache
+lockfiles, auth build mode, backend startup, and path filters aligned with local
+commands.


### PR DESCRIPTION
## Description

Add concise repository-wide agent instructions and scoped guidance for Go, Vue 3, and example app development. Document architecture, app lifecycle contracts, change-impact and compatibility requirements, validation, CI, security, references, and contribution workflows while minimizing always-loaded context.

The phēnix skill now links to shared repository guidance instead of duplicating it, and contributor branch naming is aligned with the no-slash convention.

## Related Issue

N/A

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] This PR conforms to the process detailed in the Contributing Guide.
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented code where needed; this change contains documentation only.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my changes.

## Additional Notes

Rebased onto current `main` and squashed to one commit. Validated with `git diff --check`, link/path checks, and repository Make help targets.