### PR TITLE
feat(experiment): delete injection snapshots on experiment stop

### DIFF
--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -567,10 +567,7 @@ func Start(ctx context.Context, opts ...StartOption) error {
 	} else {
 		// Delete any snapshot files created by this headnode for this experiment
 		// previously before starting the experiment. This way, cluster nodes that VMs
-		// get scheduled on will pull the most up-to-date snapshot files. We don't do
-		// this after stopping an experiment just in case users need to access the
-		// snapshots for any reason, but we do clean them up when an experiment is
-		// deleted.
+		// get scheduled on will pull the most up-to-date snapshot files.
 		err = deleteC2AndSnapshots(exp)
 		if err != nil {
 			return fmt.Errorf("deleting experiment snapshots and CC responses: %w", err)
@@ -864,9 +861,12 @@ func Start(ctx context.Context, opts ...StartOption) error {
 	return nil
 }
 
-// Stop stops the experiment with the given name. It returns any errors
-// encountered while stopping the experiment.
-func Stop(name string) error {
+// Stop stops the experiment with the given name. Injection snapshots are
+// deleted by default. It returns any errors encountered while stopping the
+// experiment.
+func Stop(name string, opts ...StopOption) error {
+	o := newStopOptions(opts...)
+
 	var err error
 	c, _ := store.NewConfig("experiment/" + name)
 
@@ -899,9 +899,9 @@ func Stop(name string) error {
 	}
 
 	if !dryrun {
-		err = mm.ClearNamespace(exp.Spec.ExperimentName())
+		err = stopVMsAndDeleteSnapshots(exp, o.keepInjectionSnapshots)
 		if err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("killing experiment VMs: %w", err))
+			errors = multierror.Append(errors, err)
 		}
 	}
 
@@ -920,6 +920,24 @@ func Stop(name string) error {
 	}
 
 	return errors
+}
+
+func stopVMsAndDeleteSnapshots(exp *types.Experiment, keepSnapshots bool) error {
+	err := mm.ClearNamespace(exp.Spec.ExperimentName())
+	if err != nil {
+		return fmt.Errorf("killing experiment VMs: %w", err)
+	}
+
+	if keepSnapshots {
+		return nil
+	}
+
+	err = deleteSnapshots(exp)
+	if err != nil {
+		return fmt.Errorf("deleting experiment snapshots: %w", err)
+	}
+
+	return nil
 }
 
 func Status(name string) (*v1.ExperimentStatus, error) {
@@ -1157,6 +1175,18 @@ func File(name, filePath string) ([]byte, error) {
 }
 
 func deleteC2AndSnapshots(exp *types.Experiment) error {
+	expName := exp.Metadata.Name
+	c2Path := expName + "/miniccc_responses"
+
+	err := file.DeleteFile(c2Path)
+	if err != nil {
+		return fmt.Errorf("deleting CC responses for experiment %s: %w", expName, err)
+	}
+
+	return deleteSnapshots(exp)
+}
+
+func deleteSnapshots(exp *types.Experiment) error {
 	// Snapshot naming convention is as follows:
 	//   {hostname}_{experiment_name}_{vm_name}_snapshot
 	// Now, we *could* use {hostname}_{experiment_name}_*_snapshot as the deletion
@@ -1176,13 +1206,6 @@ func deleteC2AndSnapshots(exp *types.Experiment) error {
 		headnode = mm.Headnode()
 	)
 
-	c2Path := expName + "/miniccc_responses"
-
-	err := file.DeleteFile(c2Path)
-	if err != nil {
-		return fmt.Errorf("deleting CC responses for experiment %s: %w", expName, err)
-	}
-
 	for _, node := range exp.Spec.Topology().Nodes() {
 		if node.External() {
 			continue
@@ -1191,7 +1214,7 @@ func deleteC2AndSnapshots(exp *types.Experiment) error {
 		hostname := node.General().Hostname()
 		snapshot := fmt.Sprintf("%s_%s_%s_snapshot", headnode, expName, hostname)
 
-		err = file.DeleteFile(snapshot)
+		err := file.DeleteFile(snapshot)
 		if err != nil {
 			return fmt.Errorf(
 				"deleting snapshot file for VM %s in experiment %s: %w",

--- a/src/go/api/experiment/option.go
+++ b/src/go/api/experiment/option.go
@@ -265,3 +265,25 @@ func StartWithMMErrorsAsWarnings(w bool) StartOption {
 		o.mmErrAsWarn = w
 	}
 }
+
+type StopOption func(*stopOptions)
+
+type stopOptions struct {
+	keepInjectionSnapshots bool
+}
+
+func newStopOptions(opts ...StopOption) stopOptions {
+	var o stopOptions
+
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return o
+}
+
+func StopWithKeepInjectionSnapshots(k bool) StopOption {
+	return func(o *stopOptions) {
+		o.keepInjectionSnapshots = k
+	}
+}

--- a/src/go/api/experiment/option_test.go
+++ b/src/go/api/experiment/option_test.go
@@ -1,0 +1,21 @@
+package experiment
+
+import "testing"
+
+func TestStopOptions(t *testing.T) {
+	t.Run("deletes injection snapshots by default", func(t *testing.T) {
+		opts := newStopOptions()
+
+		if opts.keepInjectionSnapshots {
+			t.Fatal("expected injection snapshots not to be kept")
+		}
+	})
+
+	t.Run("keeps injection snapshots when requested", func(t *testing.T) {
+		opts := newStopOptions(StopWithKeepInjectionSnapshots(true))
+
+		if !opts.keepInjectionSnapshots {
+			t.Fatal("expected injection snapshots to be kept")
+		}
+	})
+}

--- a/src/go/api/experiment/snapshot_test.go
+++ b/src/go/api/experiment/snapshot_test.go
@@ -1,0 +1,100 @@
+package experiment
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"phenix/store"
+	"phenix/types"
+	v1 "phenix/types/version/v1"
+	"phenix/util/file"
+	"phenix/util/mm"
+)
+
+type recordingClusterFiles struct {
+	file.ClusterFiles
+
+	deleted []string
+}
+
+func (f *recordingClusterFiles) DeleteFile(path string) error {
+	f.deleted = append(f.deleted, path)
+
+	return nil
+}
+
+type headnodeMM struct {
+	mm.MM
+
+	clearErr error
+}
+
+func (headnodeMM) Headnode() string {
+	return "headnode"
+}
+
+func (m headnodeMM) ClearNamespace(string) error {
+	return m.clearErr
+}
+
+func TestDeleteSnapshotsDeletesInternalVMSnapshots(t *testing.T) {
+	clusterFiles := new(recordingClusterFiles)
+	originalClusterFiles := file.DefaultClusterFiles
+	originalMM := mm.DefaultMM
+
+	file.DefaultClusterFiles = clusterFiles //nolint:reassign // install test double
+	mm.DefaultMM = headnodeMM{}             //nolint:reassign // install test double
+
+	t.Cleanup(func() {
+		file.DefaultClusterFiles = originalClusterFiles //nolint:reassign // restore default
+		mm.DefaultMM = originalMM                       //nolint:reassign // restore default
+	})
+
+	external := true
+	exp := types.NewExperiment(store.ConfigMetadata{Name: "test-exp"})
+	exp.Spec.SetTopology(&v1.TopologySpec{
+		NodesF: []*v1.Node{
+			{GeneralF: &v1.General{HostnameF: "vm-one"}},
+			{GeneralF: &v1.General{HostnameF: "outside"}, ExternalF: &external},
+		},
+	})
+
+	if err := deleteSnapshots(exp); err != nil {
+		t.Fatalf("deleting snapshots: %v", err)
+	}
+
+	want := []string{"headnode_test-exp_vm-one_snapshot"}
+	if !slices.Equal(clusterFiles.deleted, want) {
+		t.Fatalf("expected deleted snapshots %v, got %v", want, clusterFiles.deleted)
+	}
+}
+
+func TestStopVMsDoesNotDeleteSnapshotsWhenNamespaceClearFails(t *testing.T) {
+	clusterFiles := new(recordingClusterFiles)
+	originalClusterFiles := file.DefaultClusterFiles
+	originalMM := mm.DefaultMM
+
+	file.DefaultClusterFiles = clusterFiles                         //nolint:reassign // install test double
+	mm.DefaultMM = headnodeMM{clearErr: errors.New("clear failed")} //nolint:reassign // install test double
+
+	t.Cleanup(func() {
+		file.DefaultClusterFiles = originalClusterFiles //nolint:reassign // restore default
+		mm.DefaultMM = originalMM                       //nolint:reassign // restore default
+	})
+
+	exp := types.NewExperiment(store.ConfigMetadata{Name: "test-exp"})
+	exp.Spec.SetExperimentName("test-exp")
+	exp.Spec.SetTopology(&v1.TopologySpec{
+		NodesF: []*v1.Node{{GeneralF: &v1.General{HostnameF: "vm-one"}}},
+	})
+
+	err := stopVMsAndDeleteSnapshots(exp, false)
+	if err == nil {
+		t.Fatal("expected namespace clear error")
+	}
+
+	if len(clusterFiles.deleted) != 0 {
+		t.Fatalf("expected no deleted snapshots, got %v", clusterFiles.deleted)
+	}
+}

--- a/src/go/cmd/experiment.go
+++ b/src/go/cmd/experiment.go
@@ -597,8 +597,9 @@ func newExperimentStopCmd() *cobra.Command {
 		Args:              argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				name        = args[0]
-				experiments []types.Experiment
+				name                   = args[0]
+				keepInjectionSnapshots = MustGetBool(cmd.Flags(), "keep-injection-snapshots")
+				experiments            []types.Experiment
 			)
 
 			if name == allExperiments {
@@ -633,7 +634,10 @@ func newExperimentStopCmd() *cobra.Command {
 					continue
 				}
 
-				err := experiment.Stop(exp.Metadata.Name)
+				err := experiment.Stop(
+					exp.Metadata.Name,
+					experiment.StopWithKeepInjectionSnapshots(keepInjectionSnapshots),
+				)
 				if err != nil {
 					err := util.HumanizeError(
 						err,
@@ -650,6 +654,9 @@ func newExperimentStopCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().
+		BoolP("keep-injection-snapshots", "K", false, "Keep VM injection snapshots after stopping")
 
 	return cmd
 }

--- a/src/go/cmd/experiment_cmd_test.go
+++ b/src/go/cmd/experiment_cmd_test.go
@@ -15,6 +15,8 @@ import (
 	"phenix/util/mm"
 )
 
+const falseFlagDefault = "false"
+
 // fakeClusterFiles is a test double for file.ClusterFiles that no-ops
 // DeleteFile calls; any other method invocation will panic since the
 // embedded interface is left nil.
@@ -154,7 +156,7 @@ func TestExperimentDeleteForceFlagDefaultsToFalse(t *testing.T) {
 		t.Fatalf("expected force flag shorthand to be %q, got %q", "f", flag.Shorthand)
 	}
 
-	if flag.DefValue != "false" {
+	if flag.DefValue != falseFlagDefault {
 		t.Fatalf("expected force flag to default to false, got %q", flag.DefValue)
 	}
 }
@@ -231,5 +233,22 @@ func TestExperimentDeleteForceStopsRunningExperimentBeforeDeleting(t *testing.T)
 
 	if _, err := root.ExecuteC(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExperimentStopKeepInjectionSnapshotsFlag(t *testing.T) {
+	cmd := newExperimentStopCmd()
+	flag := cmd.Flags().Lookup("keep-injection-snapshots")
+
+	if flag == nil {
+		t.Fatal("expected keep-injection-snapshots flag")
+	}
+
+	if flag.DefValue != falseFlagDefault {
+		t.Fatalf("expected flag to default to false, got %q", flag.DefValue)
+	}
+	if flag.Shorthand != "K" {
+		t.Fatalf("expected flag shorthand to be %q, got %q", "K", flag.Shorthand)
+		t.Fatalf("expected flag shorthand to be %q, got %q", "K", flag.Shorthand)
 	}
 }


### PR DESCRIPTION
## Description

BEHAVIOR CHANGE: Delete VM injection snapshots by default after successful experiment shutdown. 

Add argument `--keep-injection-snapshots`/`-K` to enable the old behavior, in case the snapshots are needed for debugging.

## Related Issue
Closes #22.

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
No documentation changes required. CI, Frontend, and package workflows pass.

Also tested on a node with experiment and it works as expected. Snapshots are deleted when experiment is stopped.