### PR TITLE
builder: support file-backed topology diagrams

### DIFF
--- a/skills/phenix/SKILL.md
+++ b/skills/phenix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phenix
-description: 'Guide for using the phenix CLI and REST/web API to build and run cyber ranges, cyber experiments, and network/system emulation environments. Covers Topology (nodes, VMs, networks), Scenario (apps assigned to hosts), and Experiment (topology + scenario deployed via minimega) resources. Use when asked about phenix, phēnix, SCEPTRE, cyber range, cyber experimentation, emulation, minimega, SCORCH, or any `phenix` subcommand (config, experiment, vm, image, vlan, mm, settings, ui).'
+description: 'Guide for using the phenix CLI, REST/web API, and graphical Builder to build and run cyber ranges, cyber experiments, digital twins, and network/system emulation environments. Covers Topology, Scenario, Experiment, mxGraph builder XML, network-map and inventory conversion, and minimega deployment. Use when asked to build or translate network diagrams for cyber emulation, whenever digital twins are mentioned, or when asked about phenix, phēnix, SCEPTRE, Builder diagrams, cyber ranges, emulation, minimega, SCORCH, or any `phenix` subcommand.'
 license: GPL-3.0-only (see LICENSE)
 ---
 
@@ -204,6 +204,200 @@ experiment with a base directory, VLAN pool, bridge name, and deploy mode.
 Lifecycle: `create` → `schedule` (assign VMs to cluster hosts) → `start`
 (deploy VMs via minimega) → `stop` → `restart`/`reconfigure` → `delete`.
 An experiment also tracks runtime `status` (VM/app state) once started.
+
+## Topology Builder
+
+Builder is the graphical topology editor at `/builder`. It is a customized
+JGraph/draw.io GraphEditor backed by an **mxGraph XML model**. The diagram XML
+preserves layout, icons, labels, and per-cell configuration; Builder separately
+derives a phenix `Topology` config and experiment VLAN aliases from the cells'
+`schemaVars` JSON.
+
+### Builder API
+
+Authenticate API requests as described in [Querying the Web API](#querying-the-web-api).
+Builder endpoints use the same `/api/v1` base path:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/builder` | Load the graphical editor; this route is outside `/api/v1` |
+| `GET` | `/api/v1/builder/topologies` | List readable topology configs that contain Builder XML |
+| `GET` | `/api/v1/builder/topologies/{name}` | Return one diagram as `application/xml` |
+| `POST` | `/api/v1/experiments/builder` | Create a topology and same-named experiment |
+| `PUT` | `/api/v1/experiments/builder` | Update a Builder topology and its same-named experiment |
+| `POST` | `/builder/save` | Download XML/SVG; form fields are `filename`, `xml`, and optional `format` (`xml` or `svg`) |
+
+The experiment create/update payload is:
+
+```json
+{
+  "name": "branch-office",
+  "topology": {
+    "nodes": [
+      {
+        "type": "VirtualMachine",
+        "general": {"hostname": "client-1", "vm_type": "kvm"},
+        "hardware": {
+          "os_type": "linux",
+          "vcpus": 2,
+          "memory": 2048,
+          "drives": [{"image": "ubuntu.qc2"}]
+        },
+        "network": {
+          "interfaces": [
+            {
+              "name": "eth0",
+              "type": "ethernet",
+              "proto": "static",
+              "address": "10.10.10.10",
+              "mask": 24,
+              "gateway": "10.10.10.1",
+              "vlan": "users"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "vlans": {"users": 101},
+  "scenario": "branch-office-apps",
+  "builderXML": "<mxGraphModel>...</mxGraphModel>"
+}
+```
+
+`scenario` may be empty. To save only a topology, use the normal
+`POST /api/v1/configs` endpoint and put the XML in the topology metadata as
+described below. `POST /builder/save` returns submitted XML unchanged: the
+default `format=xml` uses `application/xml`, while `format=svg` uses
+`image/svg+xml`. It does not render PNG, GIF, JPEG, or PDF.
+
+### Storing Builder XML
+
+Builder identifies editable topologies through one of two mutually exclusive
+metadata annotations:
+
+```yaml
+# Inline form: portable, but can make topology.yaml very large.
+metadata:
+  name: branch-office
+  annotations:
+    builder-xml: |
+      <mxGraphModel>
+        ...
+      </mxGraphModel>
+```
+
+```yaml
+# File-backed form: preferred for configs maintained on disk.
+metadata:
+  name: branch-office
+  annotations:
+    builder-xml-file: ./builder/branch-office.xml
+```
+
+For `phenix config create /path/to/topology.yaml`, a relative
+`builder-xml-file` path is resolved relative to `topology.yaml`, normalized to
+an absolute path in the stored config, and read when Builder requests the
+diagram. The XML file must therefore be present and readable on the host (or
+inside the container) running `phenix ui`. Changes to that file are visible on
+the next Builder load without embedding the XML in YAML. Saving the topology
+through Builder writes the new XML back to the referenced file and preserves
+file-backed mode. Prefer absolute paths for configs submitted directly through
+the REST API because those relative paths resolve against the server process's
+working directory.
+
+### Diagram Model and Config Translation
+
+An mxGraph document has an `<mxGraphModel>` root, an inner `<root>`, reserved
+`mxCell` IDs `0` and `1`, and one cell per vertex or edge. Builder-specific
+cells wrap `mxCell` in an `<object>` (or `<Object>`) carrying:
+
+- `label`: displayed hostname or VLAN name.
+- `schemaVars`: JSON containing phenix semantics.
+- `mxCell`: graph role (`vertex="1"` or `edge="1"`), style, source/target IDs,
+  and an `mxGeometry` child.
+
+When **View JSON / Save to phenix** runs, Builder translates the graph as
+follows:
+
+1. Every vertex with `schemaVars` becomes a candidate.
+2. Vertices whose `schemaVars.device` is `switch` represent VLANs and are not
+   emitted as topology nodes.
+3. Other semantic vertices become `spec.nodes[]`; Builder removes its private
+   `device` and `schema` keys.
+4. Node `annotations` and `labels`, represented in the editor as
+   `[{key, value}]`, become phenix maps.
+5. A VLAN edge has `schemaVars` like `{"name":"users","id":101}`. Its
+   source/target relationship causes matching network interfaces to be added
+   to endpoint nodes.
+6. Each nonzero edge VLAN ID becomes an experiment alias:
+   `vlans: {"users": 101}`. ID `0` means automatic allocation.
+7. Plain shapes, text, and edges without semantic `schemaVars` are
+   diagram-only and do not affect the topology.
+8. Builder variables such as `$DEFAULT_MEMORY` are string-replaced before the
+   generated topology is submitted.
+
+Treat the diagram and generated topology as a pair. The topology is the
+deployable source of truth for phenix/minimega; XML is the editable visual
+source. After changing XML programmatically, derive or update the topology
+payload too—uploading XML alone does not regenerate `spec.nodes`.
+
+### Building Diagrams from Prompts, Images, or Inventory
+
+Use this workflow when an agent must translate a user prompt, network-map
+image, spreadsheet, CMDB export, or inventory file:
+
+1. Extract an intermediate inventory: hostname, role/icon, VM type, OS image,
+   CPU/memory, interfaces, IP/prefix, gateway, VLAN name/ID, and links.
+2. Separate facts from assumptions. Do not invent IPs, images, VLAN IDs, or
+   gateways when the input does not define them; use Builder defaults or mark
+   unresolved values for user confirmation.
+3. Normalize names to phenix constraints: unique hostnames, valid config name,
+   one canonical VLAN name per broadcast domain, and exact interface-to-VLAN
+   membership.
+4. Build and validate the phenix topology object first. This catches semantic
+   problems more reliably than reasoning directly in XML.
+5. Create the mxGraph model from that object. Prefer cloning a small
+   Builder-exported node/switch/edge as a template so styles and `schemaVars`
+   escaping remain compatible. Assign unique cell IDs and valid edge
+   `source`/`target` references.
+6. Lay out nodes by trust zone, site, subnet, or the source image's spatial
+   grouping. Use switch vertices for shared VLANs and direct semantic edges
+   only where they describe the intended broadcast domain.
+7. Keep decorative boundaries, titles, legends, and unimplemented devices free
+   of semantic `schemaVars` so they cannot become accidental VMs.
+8. Save XML with `builder-xml-file`, load the topology through
+   `phenix config create`, fetch it through
+   `/api/v1/builder/topologies/{name}`, and open **View JSON** to compare the
+   generated nodes and VLAN aliases against the intermediate inventory.
+9. Only create/start an experiment after the generated topology validates and
+   every expected node, interface, and VLAN is accounted for.
+
+For image input, visual links can cross, terminate at zone boxes, or omit
+interface details. Trace endpoints carefully and use labels/legends to
+disambiguate; do not infer that geometric proximity means connectivity. For
+inventory input, join interface records to nodes by stable identifiers before
+using display names, and detect duplicate hostnames/IPs and conflicting VLAN
+IDs before producing XML.
+
+### Builder Gotchas
+
+- **Do not put topology semantics only in labels.** Translation reads
+  `schemaVars`; a labeled icon without it is decorative.
+- **Do not change `node.type` to `kvm` or `container`.** `type` is the phenix
+  role (`VirtualMachine`, `Router`, `Firewall`, etc.); VM implementation belongs
+  in `general.vm_type`.
+- **Do not define both XML annotations.** `builder-xml` and
+  `builder-xml-file` are mutually exclusive.
+- **Keep file-backed XML server-local.** Browser/client paths are not visible
+  to the phenix server or container.
+- **Preserve XML escaping.** JSON inside an XML attribute must escape quotes
+  (normally `&quot;`). Prefer an XML library rather than string concatenation.
+- **Validate both representations.** A valid mxGraph document can still
+  generate an invalid topology, and valid topology YAML does not guarantee its
+  diagram matches.
+- **Use exact scenario topology membership.** Scenario `topology` annotations
+  are comma-separated names; avoid substring tests and duplicate entries.
 
 ## CLI Reference
 

--- a/src/go/api/config/builder.go
+++ b/src/go/api/config/builder.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"phenix/store"
+)
+
+const (
+	BuilderXMLAnnotation     = "builder-xml"
+	BuilderXMLFileAnnotation = "builder-xml-file"
+)
+
+// HasBuilderXML reports whether a config references embedded or file-backed Builder XML.
+func HasBuilderXML(c store.Config) bool {
+	return c.HasAnnotation(BuilderXMLAnnotation) || c.HasAnnotation(BuilderXMLFileAnnotation)
+}
+
+// BuilderXML loads the Builder diagram associated with a config.
+func BuilderXML(c store.Config) ([]byte, error) {
+	xml, embedded := c.Metadata.Annotations[BuilderXMLAnnotation]
+	path, fromFile := c.Metadata.Annotations[BuilderXMLFileAnnotation]
+
+	if embedded && fromFile {
+		return nil, fmt.Errorf(
+			"annotations %q and %q are mutually exclusive",
+			BuilderXMLAnnotation,
+			BuilderXMLFileAnnotation,
+		)
+	}
+
+	if embedded {
+		return []byte(xml), nil
+	}
+
+	if !fromFile {
+		return nil, errors.New("builder XML annotation missing")
+	}
+
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("annotation %q cannot be empty", BuilderXMLFileAnnotation)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading builder XML file %q: %w", path, err)
+	}
+
+	return data, nil
+}
+
+// WriteBuilderXMLFile replaces the diagram for a file-backed Builder config.
+func WriteBuilderXMLFile(c store.Config, data []byte) error {
+	if c.HasAnnotation(BuilderXMLAnnotation) {
+		return fmt.Errorf(
+			"annotation %q cannot be used with %q",
+			BuilderXMLAnnotation,
+			BuilderXMLFileAnnotation,
+		)
+	}
+
+	path, ok := c.Metadata.Annotations[BuilderXMLFileAnnotation]
+	if !ok || strings.TrimSpace(path) == "" {
+		return fmt.Errorf("annotation %q missing or empty", BuilderXMLFileAnnotation)
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("resolving builder XML file %q: %w", path, err)
+	}
+
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return fmt.Errorf("statting builder XML file %q: %w", path, err)
+	}
+
+	temp, err := os.CreateTemp(
+		filepath.Dir(resolvedPath),
+		"."+filepath.Base(resolvedPath)+".*",
+	)
+	if err != nil {
+		return fmt.Errorf("creating temporary builder XML file: %w", err)
+	}
+
+	tempPath := temp.Name()
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := temp.Chmod(info.Mode().Perm()); err != nil {
+		_ = temp.Close()
+
+		return fmt.Errorf("setting builder XML file permissions: %w", err)
+	}
+
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+
+		return fmt.Errorf("writing builder XML file: %w", err)
+	}
+
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+
+		return fmt.Errorf("syncing builder XML file: %w", err)
+	}
+
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("closing builder XML file: %w", err)
+	}
+
+	if err := os.Rename(tempPath, resolvedPath); err != nil {
+		return fmt.Errorf("replacing builder XML file %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func normalizeBuilderXMLFilePath(c *store.Config, source string) error {
+	if c.Kind != "Topology" || c.Metadata.Annotations == nil {
+		return nil
+	}
+
+	path, ok := c.Metadata.Annotations[BuilderXMLFileAnnotation]
+	if !ok || strings.TrimSpace(path) == "" || filepath.IsAbs(path) {
+		return nil
+	}
+
+	base := "."
+	if source != "" {
+		base = filepath.Dir(source)
+	}
+
+	path, err := filepath.Abs(filepath.Join(base, path))
+	if err != nil {
+		return fmt.Errorf("resolving builder XML file %q: %w", path, err)
+	}
+
+	c.Metadata.Annotations[BuilderXMLFileAnnotation] = filepath.Clean(path)
+
+	return nil
+}
+
+func validateBuilderAnnotations(stage string, c *store.Config) error {
+	if c.Kind != "Topology" || (stage != "create" && stage != "update" && stage != "startup") {
+		return nil
+	}
+
+	if !HasBuilderXML(*c) {
+		return nil
+	}
+
+	if _, err := BuilderXML(*c); err != nil {
+		return fmt.Errorf("loading builder XML: %w", err)
+	}
+
+	return nil
+}
+
+func init() { //nolint:gochecknoinits // config hook
+	RegisterConfigHook("Topology", validateBuilderAnnotations)
+}

--- a/src/go/api/config/builder_test.go
+++ b/src/go/api/config/builder_test.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"phenix/store"
+)
+
+func TestBuilderXML(t *testing.T) {
+	t.Run("embedded", func(t *testing.T) {
+		cfg := store.Config{
+			Metadata: store.ConfigMetadata{
+				Annotations: store.Annotations{BuilderXMLAnnotation: "<mxGraphModel/>"},
+			},
+		}
+
+		got, err := BuilderXML(cfg)
+		if err != nil {
+			t.Fatalf("BuilderXML() returned error: %v", err)
+		}
+		if string(got) != "<mxGraphModel/>" {
+			t.Fatalf("BuilderXML() = %q, want embedded XML", got)
+		}
+	})
+
+	t.Run("file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "topology.xml")
+		if err := os.WriteFile(path, []byte("<mxGraphModel/>"), 0o600); err != nil {
+			t.Fatalf("writing builder XML: %v", err)
+		}
+
+		cfg := store.Config{
+			Metadata: store.ConfigMetadata{
+				Annotations: store.Annotations{BuilderXMLFileAnnotation: path},
+			},
+		}
+
+		got, err := BuilderXML(cfg)
+		if err != nil {
+			t.Fatalf("BuilderXML() returned error: %v", err)
+		}
+		if string(got) != "<mxGraphModel/>" {
+			t.Fatalf("BuilderXML() = %q, want file contents", got)
+		}
+	})
+
+	t.Run("annotations are mutually exclusive", func(t *testing.T) {
+		cfg := store.Config{
+			Metadata: store.ConfigMetadata{
+				Annotations: store.Annotations{
+					BuilderXMLAnnotation:     "<mxGraphModel/>",
+					BuilderXMLFileAnnotation: "topology.xml",
+				},
+			},
+		}
+
+		_, err := BuilderXML(cfg)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("BuilderXML() error = %v, want mutually exclusive error", err)
+		}
+	})
+}
+
+func TestNormalizeBuilderXMLFilePath(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "topology.yaml")
+	cfg := store.Config{
+		Kind: "Topology",
+		Metadata: store.ConfigMetadata{
+			Annotations: store.Annotations{BuilderXMLFileAnnotation: "builder/topology.xml"},
+		},
+	}
+
+	if err := normalizeBuilderXMLFilePath(&cfg, source); err != nil {
+		t.Fatalf("normalizeBuilderXMLFilePath() returned error: %v", err)
+	}
+
+	want := filepath.Join(dir, "builder", "topology.xml")
+	if got := cfg.Metadata.Annotations[BuilderXMLFileAnnotation]; got != want {
+		t.Fatalf("normalized path = %q, want %q", got, want)
+	}
+}
+
+func TestWriteBuilderXMLFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "topology.xml")
+	if err := os.WriteFile(path, []byte("<mxGraphModel/>"), 0o640); err != nil {
+		t.Fatalf("writing builder XML: %v", err)
+	}
+
+	cfg := store.Config{
+		Metadata: store.ConfigMetadata{
+			Annotations: store.Annotations{BuilderXMLFileAnnotation: path},
+		},
+	}
+
+	want := "<mxGraphModel><root/></mxGraphModel>"
+	if err := WriteBuilderXMLFile(cfg, []byte(want)); err != nil {
+		t.Fatalf("WriteBuilderXMLFile() returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading builder XML: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("builder XML = %q, want %q", got, want)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("statting builder XML: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("permissions = %o, want 640", got)
+	}
+}
+
+func TestCreateFromPathNormalizesBuilderXMLFile(t *testing.T) {
+	dir := t.TempDir()
+	xmlPath := filepath.Join(dir, "builder", "topology.xml")
+	if err := os.Mkdir(filepath.Dir(xmlPath), 0o750); err != nil {
+		t.Fatalf("creating builder directory: %v", err)
+	}
+	if err := os.WriteFile(xmlPath, []byte("<mxGraphModel/>"), 0o640); err != nil {
+		t.Fatalf("writing builder XML: %v", err)
+	}
+
+	configPath := filepath.Join(dir, "topology.yaml")
+	configYAML := `apiVersion: phenix.sandia.gov/v1
+kind: Topology
+metadata:
+  name: test
+  annotations:
+    builder-xml-file: ./builder/topology.xml
+spec:
+  nodes: []
+`
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o600); err != nil {
+		t.Fatalf("writing topology config: %v", err)
+	}
+
+	ctrl := gomock.NewController(t)
+	mock := store.NewMockStore(ctrl)
+	mock.EXPECT().Create(gomock.Any()).DoAndReturn(func(cfg *store.Config) error {
+		if got := cfg.Metadata.Annotations[BuilderXMLFileAnnotation]; got != xmlPath {
+			t.Fatalf("stored builder XML path = %q, want %q", got, xmlPath)
+		}
+
+		return nil
+	})
+
+	previousStore := store.DefaultStore
+	store.DefaultStore = mock
+	t.Cleanup(func() {
+		store.DefaultStore = previousStore
+	})
+
+	if _, err := Create(CreateFromPath(configPath)); err != nil {
+		t.Fatalf("Create() returned error: %v", err)
+	}
+}

--- a/src/go/api/config/config.go
+++ b/src/go/api/config/config.go
@@ -342,6 +342,10 @@ func Create(opts ...CreateOption) (*store.Config, error) {
 		return nil, errors.New("no config, path, or data provided")
 	}
 
+	if err := normalizeBuilderXMLFilePath(c, o.path); err != nil {
+		return nil, err
+	}
+
 	if o.validate {
 		validateErr := types.ValidateConfigSpec(*c)
 		if validateErr != nil {
@@ -444,6 +448,10 @@ func Edit(name string, force bool) (*store.Config, error) {
 // changed as part of the update, a new config will be created and the old
 // config deleted.
 func Update(name string, c *store.Config) error {
+	if err := normalizeBuilderXMLFilePath(c, ""); err != nil {
+		return err
+	}
+
 	old, err := store.NewConfig(name)
 	if err != nil {
 		return fmt.Errorf("getting config to update: %w", err)

--- a/src/go/web/builder.go
+++ b/src/go/web/builder.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"html/template"
 	"io"
+	"mime"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -36,6 +35,42 @@ type builder struct {
 	Scenario string         `json:"scenario"`
 	Name     string         `json:"name"`
 	XML      string         `json:"builderXML"`
+}
+
+func validateBuilderRequest(req builder) error {
+	switch {
+	case strings.TrimSpace(req.Name) == "":
+		return errors.New("topology name is required")
+	case req.Topology == nil:
+		return errors.New("topology spec is required")
+	case strings.TrimSpace(req.XML) == "":
+		return errors.New("builder XML is required")
+	default:
+		return nil
+	}
+}
+
+func addScenarioTopology(scenario *store.Config, topology string) {
+	if scenario.Metadata.Annotations == nil {
+		scenario.Metadata.Annotations = make(store.Annotations)
+	}
+
+	topologies := strings.Split(scenario.Metadata.Annotations["topology"], ",")
+	for _, existing := range topologies {
+		if strings.TrimSpace(existing) == topology {
+			return
+		}
+	}
+
+	topologies = append(topologies, topology)
+	nonempty := topologies[:0]
+	for _, name := range topologies {
+		if name = strings.TrimSpace(name); name != "" {
+			nonempty = append(nonempty, name)
+		}
+	}
+
+	scenario.Metadata.Annotations["topology"] = strings.Join(nonempty, ",")
 }
 
 // GetBuilder - GET /builder.
@@ -96,11 +131,19 @@ func CreateExperimentFromBuilder(w http.ResponseWriter, r *http.Request) error {
 		return weberror.NewWebError(err, "unmarshaling request body")
 	}
 
+	if err := validateBuilderRequest(req); err != nil {
+		return weberror.NewWebError(err, "invalid builder request")
+	}
+
 	// create new topology
 
-	topo, _ := store.NewConfig("topology/" + req.Name)
+	topo, err := store.NewConfig("topology/" + req.Name)
+	if err != nil {
+		return weberror.NewWebError(err, "creating topology config").
+			WithMetadata("type", "topology", true)
+	}
 
-	topo.Metadata.Annotations = store.Annotations{"builder-xml": req.XML}
+	topo.Metadata.Annotations = store.Annotations{config.BuilderXMLAnnotation: req.XML}
 	topo.Spec = req.Topology
 
 	config, err := config.Create(config.CreateFromConfig(topo), config.CreateWithValidation())
@@ -150,19 +193,19 @@ func CreateExperimentFromBuilder(w http.ResponseWriter, r *http.Request) error {
 	defer cache.UnlockExperiment(req.Name)
 
 	if req.Scenario != "" {
-		scenario, _ := store.NewConfig("scenario/" + req.Scenario)
+		scenario, err := store.NewConfig("scenario/" + req.Scenario)
+		if err != nil {
+			return weberror.NewWebError(err, "creating scenario config")
+		}
 
-		err := store.Get(scenario)
+		err = store.Get(scenario)
 		if err != nil {
 			return weberror.NewWebError(nil, "scenario %s doesn't exist", req.Scenario)
 		}
 
 		// add this new topology to the given scenario
 
-		topo := scenario.Metadata.Annotations["topology"]
-		topo = fmt.Sprintf("%s,%s", topo, req.Name)
-
-		scenario.Metadata.Annotations["topology"] = topo
+		addScenarioTopology(scenario, req.Name)
 
 		err = store.Update(scenario)
 		if err != nil {
@@ -294,11 +337,31 @@ func UpdateExperimentFromBuilder(w http.ResponseWriter, r *http.Request) error {
 		return weberror.NewWebError(err, "unmarshaling request body")
 	}
 
+	if err := validateBuilderRequest(req); err != nil {
+		return weberror.NewWebError(err, "invalid builder request")
+	}
+
 	// update existing topology
 
-	topo, _ := store.NewConfig("topology/" + req.Name)
+	topo, err := config.Get(store.ConfigFullName("topology", req.Name), false)
+	if err != nil {
+		if errors.Is(err, store.ErrNotExist) {
+			return weberror.NewWebError(err, "topology with same name doesn't exist yet").
+				WithMetadata("type", "topology", true)
+		}
 
-	topo.Metadata.Annotations = store.Annotations{"builder-xml": req.XML}
+		return weberror.NewWebError(err, "getting topology %s", req.Name).
+			SetStatus(http.StatusInternalServerError)
+	}
+
+	if topo.Metadata.Annotations == nil {
+		topo.Metadata.Annotations = make(store.Annotations)
+	}
+
+	fileBacked := topo.HasAnnotation(config.BuilderXMLFileAnnotation)
+	if !fileBacked {
+		topo.Metadata.Annotations[config.BuilderXMLAnnotation] = req.XML
+	}
 	topo.Spec = req.Topology
 
 	if err := config.Update(topo.FullName(), topo); err != nil {
@@ -318,6 +381,13 @@ func UpdateExperimentFromBuilder(w http.ResponseWriter, r *http.Request) error {
 
 		return weberror.NewWebError(err, "unable to update existing topology").
 			WithMetadata("type", "topology", true)
+	}
+
+	if fileBacked {
+		if err := config.WriteBuilderXMLFile(*topo, []byte(req.XML)); err != nil {
+			return weberror.NewWebError(err, "updating builder XML file").
+				SetStatus(http.StatusInternalServerError)
+		}
 	}
 
 	// Grab this now, before we clear the spec from the toplology config, just in
@@ -414,6 +484,36 @@ func UpdateExperimentFromBuilder(w http.ResponseWriter, r *http.Request) error {
 		// update existing experiment
 
 		exp.Spec.SetTopology(topoSpec)
+		exp.Spec.VLANs().SetAliases(req.VLANs)
+
+		if req.Scenario != "" && annotations["scenario"] != req.Scenario {
+			scenario, err := store.NewConfig("scenario/" + req.Scenario)
+			if err != nil {
+				return weberror.NewWebError(err, "creating scenario config")
+			}
+
+			if err := store.Get(scenario); err != nil {
+				return weberror.NewWebError(err, "getting scenario %s", req.Scenario)
+			}
+
+			addScenarioTopology(scenario, req.Name)
+			if err := store.Update(scenario); err != nil {
+				return weberror.NewWebError(err, "updating scenario %s", req.Scenario).
+					SetStatus(http.StatusInternalServerError)
+			}
+
+			scenarioSpec, err := types.DecodeScenarioFromConfig(*scenario)
+			if err != nil {
+				return weberror.NewWebError(err, "decoding scenario %s", req.Scenario)
+			}
+
+			if err := types.MergeScenariosForTopology(scenarioSpec, req.Name); err != nil {
+				return weberror.NewWebError(err, "merging scenario %s", req.Scenario)
+			}
+
+			exp.Spec.SetScenario(scenarioSpec)
+			exp.Metadata.Annotations["scenario"] = req.Scenario
+		}
 
 		err = exp.WriteToStore(false)
 		if err != nil {
@@ -432,19 +532,19 @@ func UpdateExperimentFromBuilder(w http.ResponseWriter, r *http.Request) error {
 		defer cache.UnlockExperiment(req.Name)
 
 		if req.Scenario != "" {
-			scenario, _ := store.NewConfig("scenario/" + req.Scenario)
+			scenario, err := store.NewConfig("scenario/" + req.Scenario)
+			if err != nil {
+				return weberror.NewWebError(err, "creating scenario config")
+			}
 
-			err := store.Get(scenario)
+			err = store.Get(scenario)
 			if err != nil {
 				return weberror.NewWebError(nil, "scenario %s doesn't exist", req.Scenario)
 			}
 
 			// add this topology to the given scenario
 
-			topo := scenario.Metadata.Annotations["topology"]
-			topo = fmt.Sprintf("%s,%s", topo, req.Name)
-
-			scenario.Metadata.Annotations["topology"] = topo
+			addScenarioTopology(scenario, req.Name)
 
 			err = store.Update(scenario)
 			if err != nil {
@@ -552,21 +652,31 @@ func SaveBuilderTopology(w http.ResponseWriter, r *http.Request) {
 		name = "export"
 	}
 
+	data := r.FormValue("xml")
+	if data == "" {
+		http.Error(w, "builder topology XML is required", http.StatusBadRequest)
+		return
+	}
+
 	format := r.FormValue("format")
 	if format == "" {
 		format = "xml"
 	}
 
-	data, err := url.QueryUnescape(r.FormValue("xml"))
-	if err != nil {
-		msg := "unable to decode builder topology XML"
-		http.Error(w, msg, http.StatusBadRequest)
-
+	contentTypes := map[string]string{
+		"svg": "image/svg+xml; charset=utf-8",
+		"xml": "application/xml; charset=utf-8",
+	}
+	contentType, ok := contentTypes[format]
+	if !ok {
+		http.Error(w, "unsupported builder download format", http.StatusBadRequest)
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/plain")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, name))
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{
+		"filename": name,
+	}))
 	plog.Info(plog.TypeAction, "downloading builder file", "file", name, "format", format)
 	http.ServeContent(w, r, "", time.Now(), bytes.NewReader([]byte(data)))
 }
@@ -607,10 +717,8 @@ func GetBuilderTopologies(w http.ResponseWriter, r *http.Request) error {
 	allowed := []string{}
 
 	for _, topo := range topologies {
-		if role.Allowed("topologies", "list", topo.Metadata.Name) {
-			if topo.HasAnnotation("builder-xml") {
-				allowed = append(allowed, topo.Metadata.Name)
-			}
+		if role.Allowed("configs", "get", topo.FullName()) && config.HasBuilderXML(topo) {
+			allowed = append(allowed, topo.Metadata.Name)
 		}
 	}
 
@@ -639,7 +747,7 @@ func GetBuilderTopology(w http.ResponseWriter, r *http.Request) error {
 		name    = store.ConfigFullName("topology", vars["name"])
 	)
 
-	if !role.Allowed("configs", "list", name) {
+	if !role.Allowed("configs", "get", name) {
 		user, _ := ctx.Value(middleware.ContextKeyUser).(string)
 		plog.Warn(
 			plog.TypeSecurity,
@@ -661,12 +769,16 @@ func GetBuilderTopology(w http.ResponseWriter, r *http.Request) error {
 
 	topology, err := config.Get(name, false)
 	if err != nil {
-		err := weberror.NewWebError(err, "unable to get topology %s from store", vars["name"])
+		if errors.Is(err, store.ErrNotExist) {
+			return weberror.NewWebError(err, "unable to get topology %s from store", vars["name"]).
+				SetStatus(http.StatusNotFound)
+		}
 
-		return err.SetStatus(http.StatusInternalServerError)
+		return weberror.NewWebError(err, "unable to get topology %s from store", vars["name"]).
+			SetStatus(http.StatusInternalServerError)
 	}
 
-	if !topology.HasAnnotation("builder-xml") {
+	if !config.HasBuilderXML(*topology) {
 		return weberror.NewWebError(
 			nil,
 			"the %s topology does not include a builder XML config",
@@ -674,7 +786,11 @@ func GetBuilderTopology(w http.ResponseWriter, r *http.Request) error {
 		)
 	}
 
-	body := []byte(topology.Metadata.Annotations["builder-xml"])
+	body, err := config.BuilderXML(*topology)
+	if err != nil {
+		return weberror.NewWebError(err, "unable to load builder XML for topology %s", vars["name"]).
+			SetStatus(http.StatusInternalServerError)
+	}
 
 	w.Header().Set("Content-Type", "application/xml")
 	_, _ = w.Write(body)

--- a/src/go/web/builder_test.go
+++ b/src/go/web/builder_test.go
@@ -1,0 +1,131 @@
+package web
+
+import (
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"phenix/store"
+)
+
+func TestSaveBuilderTopology(t *testing.T) {
+	xml := `<mxGraphModel value="%2B"/>`
+	form := url.Values{
+		"filename": {`diagram "one".xml`},
+		"xml":      {xml},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/builder/save", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+
+	SaveBuilderTopology(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+	if got := res.Body.String(); got != xml {
+		t.Fatalf("body = %q, want %q", got, xml)
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/xml; charset=utf-8" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+
+	_, params, err := mime.ParseMediaType(res.Header().Get("Content-Disposition"))
+	if err != nil {
+		t.Fatalf("parsing Content-Disposition: %v", err)
+	}
+	if got := params["filename"]; got != `diagram "one".xml` {
+		t.Fatalf("filename = %q", got)
+	}
+}
+
+func TestSaveBuilderTopologySVG(t *testing.T) {
+	form := url.Values{
+		"filename": {"diagram.svg"},
+		"format":   {"svg"},
+		"xml":      {"<svg/>"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/builder/save", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+
+	SaveBuilderTopology(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+	if got := res.Header().Get("Content-Type"); got != "image/svg+xml; charset=utf-8" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+}
+
+func TestSaveBuilderTopologyRejectsUnsupportedFormat(t *testing.T) {
+	form := url.Values{
+		"format": {"png"},
+		"xml":    {"<output/>"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/builder/save", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+
+	SaveBuilderTopology(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusBadRequest)
+	}
+}
+
+func TestSaveBuilderTopologyRequiresXML(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/builder/save", nil)
+	res := httptest.NewRecorder()
+
+	SaveBuilderTopology(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusBadRequest)
+	}
+}
+
+func TestValidateBuilderRequest(t *testing.T) {
+	valid := builder{
+		Name:     "test",
+		Topology: map[string]any{"nodes": []any{}},
+		XML:      "<mxGraphModel/>",
+	}
+
+	tests := []struct {
+		name string
+		req  builder
+	}{
+		{name: "missing name", req: builder{Topology: valid.Topology, XML: valid.XML}},
+		{name: "missing topology", req: builder{Name: valid.Name, XML: valid.XML}},
+		{name: "missing XML", req: builder{Name: valid.Name, Topology: valid.Topology}},
+	}
+
+	if err := validateBuilderRequest(valid); err != nil {
+		t.Fatalf("valid request returned error: %v", err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateBuilderRequest(test.req); err == nil {
+				t.Fatal("validateBuilderRequest() returned no error")
+			}
+		})
+	}
+}
+
+func TestAddScenarioTopology(t *testing.T) {
+	scenario := &store.Config{}
+
+	addScenarioTopology(scenario, "alpha")
+	addScenarioTopology(scenario, "alpha")
+	addScenarioTopology(scenario, "beta")
+
+	if got := scenario.Metadata.Annotations["topology"]; got != "alpha,beta" {
+		t.Fatalf("topology annotation = %q, want %q", got, "alpha,beta")
+	}
+}

--- a/src/go/web/public/grapheditor/js/Actions.js
+++ b/src/go/web/public/grapheditor/js/Actions.js
@@ -126,12 +126,10 @@ Actions.prototype.init = function()
                         success: function (data) {
                             // Dynamically update path to pictures used when a file is imported.
                             var stencilPath = window.parent.STENCIL_PATH;
-                            var imageEquals = "image=";
-                            var vmPath = "/virtual_machines"
-                            var partialPath = imageEquals + stencilPath;
-                            var fullPath = partialPath + vmPath;
-                            const regex = /image=/g;
-                            var cleanData = data.replace(regex, fullPath)
+                            var cleanData = data.replace(
+                                /image=[^;"]*(\/(?:virtual_machines|containers)\/)/g,
+                                'image=' + stencilPath + '$1'
+                            );
 
                             var doc = mxUtils.parseXml(cleanData);
                             editor.graph.setSelectionCells(editor.graph.importGraphModel(doc.documentElement));

--- a/src/go/web/public/grapheditor/js/Dialogs.js
+++ b/src/go/web/public/grapheditor/js/Dialogs.js
@@ -998,30 +998,6 @@ var ExportDialog = function(editorUi)
     var imageFormatSelect = document.createElement('select');
     imageFormatSelect.style.width = '180px';
 
-    var pngOption = document.createElement('option');
-    pngOption.setAttribute('value', 'png');
-    mxUtils.write(pngOption, mxResources.get('formatPng'));
-    imageFormatSelect.appendChild(pngOption);
-
-    var gifOption = document.createElement('option');
-    
-    if (ExportDialog.showGifOption)
-    {
-        gifOption.setAttribute('value', 'gif');
-        mxUtils.write(gifOption, mxResources.get('formatGif'));
-        imageFormatSelect.appendChild(gifOption);
-    }
-    
-    var jpgOption = document.createElement('option');
-    jpgOption.setAttribute('value', 'jpg');
-    mxUtils.write(jpgOption, mxResources.get('formatJpg'));
-    imageFormatSelect.appendChild(jpgOption);
-
-    var pdfOption = document.createElement('option');
-    pdfOption.setAttribute('value', 'pdf');
-    mxUtils.write(pdfOption, mxResources.get('formatPdf'));
-    imageFormatSelect.appendChild(pdfOption);
-    
     var svgOption = document.createElement('option');
     svgOption.setAttribute('value', 'svg');
     mxUtils.write(svgOption, mxResources.get('formatSvg'));
@@ -1424,11 +1400,6 @@ var ExportDialog = function(editorUi)
  * Remembers last value for border.
  */
 ExportDialog.lastBorderValue = 0;
-
-/**
- * Global switches for the export dialog.
- */
-ExportDialog.showGifOption = true;
 
 /**
  * Global switches for the export dialog.
@@ -4577,16 +4548,16 @@ var ImportJSONDialog = function(graph, ui) {
                         device = 'desktop';
                     }
                     node.device = device;
-                    // default to type kvm
-                    var type = node.type || 'kvm';
-                    type = type.toLowerCase();
-                    if (!types.includes(type)) {
-                        type = 'kvm';
+                    // VM implementation controls the icon variant; node.type is
+                    // the phēnix role and must remain unchanged.
+                    var vmType = node.general && node.general.vm_type || 'kvm';
+                    vmType = vmType.toLowerCase();
+                    if (!types.includes(vmType)) {
+                        vmType = 'kvm';
                     }
-                    node.type = type;
                     // build node styling string based on device and type
-                    var imageDir = (type == 'kvm') ? "/virtual_machines" : "/containers";
-                    var imageType = (type == 'kvm') ? "vm" : "container";
+                    var imageDir = (vmType == 'kvm') ? "/virtual_machines" : "/containers";
+                    var imageType = (vmType == 'kvm') ? "vm" : "container";
                     var styleString = vertexStyleString + stencilsDir + imageDir + "/" + device + "_blue_" + imageType + ".png";
                     obj.style = styleString;
                     obj.geometry = {width: 80, height: 80};
@@ -4620,7 +4591,7 @@ var ImportJSONDialog = function(graph, ui) {
                         for (var i = 0; i < ifaces.length; i++) {
                             var name = ifaces[i].vlan;
                             if (!vlans[name]) {
-                                var vlan = {"id": 'auto', "name": name, "type": type};
+                                var vlan = {"id": 'auto', "name": name, "type": vmType};
                                 vlan.targets = [];
                                 vlans[name] = vlan;
                             }


### PR DESCRIPTION
> [!IMPORTANT]
> **Very much a work in progress. Do not review or merge yet. Comments and early feedback are welcome.**

## Summary
- Support file-backed Builder XML in topology configs.
- Harden Builder API, exports, and diagram imports.
- Document Builder workflows and add focused tests.

## Validation
- `go test -race ./api/config ./web`
- `go test -run '^$' ./...`
- Full suite has two unrelated macOS Unix-socket path failures.
