### PR TITLE
feat(cli): support starting/stopping per-interface VM packet captures

### DIFF
--- a/src/go/api/vm/capture.go
+++ b/src/go/api/vm/capture.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"phenix/api/experiment"
 	"phenix/util/mm"
@@ -14,6 +16,37 @@ var (
 	ErrCaptureExists = errors.New("capture already exists")
 	ErrNoCaptures    = errors.New("no captures exist")
 )
+
+// ResolveInterface resolves the given interface identifier - either a
+// zero-based index (e.g. "0") or the interface name as declared in the
+// experiment topology (e.g. "IF0") - to the interface's zero-based index for
+// the given VM. Name matching is case-insensitive. It returns an error if the
+// identifier doesn't match a valid interface index or name for the VM.
+func ResolveInterface(v *mm.VM, iface string) (int, error) {
+	if v == nil {
+		return 0, errors.New("no VM details provided")
+	}
+
+	if iface == "" {
+		return 0, errors.New("no interface identifier provided")
+	}
+
+	if idx, err := strconv.Atoi(iface); err == nil {
+		if idx < 0 || idx >= len(v.Networks) {
+			return 0, fmt.Errorf("interface index %d is out of range for VM %s", idx, v.Name)
+		}
+
+		return idx, nil
+	}
+
+	for idx, name := range v.IfaceNames {
+		if strings.EqualFold(name, iface) {
+			return idx, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no interface named %q found for VM %s", iface, v.Name)
+}
 
 // StartCapture starts a packet capture on the given interface for the given VM
 // in the given experiment. The captured packets are written to the experiment's
@@ -32,20 +65,45 @@ func StartCapture(expName, vmName string, iface int, out string) error {
 		return errors.New("no output file provided")
 	}
 
-	vm, err := Get(expName, vmName)
+	v, err := Get(expName, vmName)
 	if err != nil {
 		return fmt.Errorf("getting VM details: %w", err)
 	}
 
-	if !vm.Running {
+	return StartCaptureForVM(v, expName, vmName, iface, out)
+}
+
+// StartCaptureForVM behaves like StartCapture, but accepts an already-fetched
+// VM instead of looking it up itself. Callers that already have the VM's
+// details on hand (e.g. because they resolved an interface name to an index
+// via ResolveInterface, which also requires the VM's details) should use this
+// to avoid an extra, redundant VM lookup.
+func StartCaptureForVM(v *mm.VM, expName, vmName string, iface int, out string) error {
+	if v == nil {
+		return errors.New("no VM details provided")
+	}
+
+	if expName == "" {
+		return errors.New("no experiment name provided")
+	}
+
+	if vmName == "" {
+		return errors.New("no VM name provided")
+	}
+
+	if out == "" {
+		return errors.New("no output file provided")
+	}
+
+	if !v.Running {
 		return errors.New("vm is not running")
 	}
 
-	if iface < 0 || iface >= len(vm.Networks) {
+	if iface < 0 || iface >= len(v.Networks) {
 		return errors.New("invalid interface provided for capture")
 	}
 
-	if vm.Networks[iface] == "disconnected" {
+	if v.Networks[iface] == "disconnected" {
 		return errors.New("cannot capture on a disconnected interface")
 	}
 
@@ -74,10 +132,28 @@ func StartCapture(expName, vmName string, iface int, out string) error {
 }
 
 // StopCaptures stops all currently running packet captures for the given VM in
-// the given experiment. Due to a limitation in minimega, it is not possible to
-// stop a single capture if more than one capture is running for a VM. It
-// returns any errors encountered while stopping the packet captures.
+// the given experiment. It returns any errors encountered while stopping the
+// packet captures.
 func StopCaptures(expName, vmName string) error {
+	return stopCaptures(expName, vmName, nil)
+}
+
+// StopCapture stops the packet capture running on the given interface for the
+// given VM in the given experiment, leaving any other running captures for
+// the VM untouched. It returns any errors encountered while stopping the
+// packet capture.
+func StopCapture(expName, vmName string, iface int) error {
+	if iface < 0 {
+		return errors.New("invalid interface provided for capture")
+	}
+
+	return stopCaptures(expName, vmName, &iface)
+}
+
+// stopCaptures stops packet captures for the given VM in the given
+// experiment. If iface is non-nil, only the capture running on that
+// interface index is stopped; otherwise all captures for the VM are stopped.
+func stopCaptures(expName, vmName string, iface *int) error {
 	if expName == "" {
 		return errors.New("no experiment name provided")
 	}
@@ -92,6 +168,27 @@ func StopCaptures(expName, vmName string) error {
 		return fmt.Errorf("vm %s in experiment %s: %w", vmName, expName, ErrNoCaptures)
 	}
 
+	if iface != nil {
+		var found bool
+
+		for _, capture := range captures {
+			if capture.Interface == *iface {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf(
+				"interface %d on VM %s in experiment %s: %w",
+				*iface,
+				vmName,
+				expName,
+				ErrNoCaptures,
+			)
+		}
+	}
+
 	exp, err := experiment.Get(expName)
 	if err != nil {
 		return fmt.Errorf("getting experiment %s: %w", expName, err)
@@ -103,7 +200,23 @@ func StopCaptures(expName, vmName string) error {
 		return fmt.Errorf("creating files directory for experiment %s: %w", expName, err)
 	}
 
-	if err := mm.StopVMCapture(mm.NS(expName), mm.VMName(vmName)); err != nil {
+	opts := []mm.Option{mm.NS(expName), mm.VMName(vmName)}
+
+	if iface != nil {
+		opts = append(opts, mm.CaptureInterface(*iface))
+	}
+
+	if err := mm.StopVMCapture(opts...); err != nil {
+		if iface != nil {
+			return fmt.Errorf(
+				"stopping VM capture for interface %d on VM %s in experiment %s: %w",
+				*iface,
+				vmName,
+				expName,
+				err,
+			)
+		}
+
 		return fmt.Errorf(
 			"stopping VM captures for VM %s in experiment %s: %w",
 			vmName,

--- a/src/go/api/vm/capture_test.go
+++ b/src/go/api/vm/capture_test.go
@@ -1,0 +1,757 @@
+package vm_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"phenix/api/vm"
+	"phenix/store"
+	"phenix/util/mm"
+)
+
+// captureTestMM is a test double for mm.MM. Embedding the (nil) mm.MM
+// interface means any method call this test doesn't stub will panic, which
+// is fine since these tests only ever exercise the capture-related methods.
+type captureTestMM struct {
+	mm.MM
+
+	vmInfo   mm.VMs
+	captures []mm.Capture
+
+	startErr error
+	stopErr  error
+
+	startCalls int
+	stopCalls  int
+}
+
+func (m *captureTestMM) GetVMInfo(...mm.Option) mm.VMs {
+	return m.vmInfo
+}
+
+func (m *captureTestMM) GetVMCaptures(...mm.Option) []mm.Capture {
+	return m.captures
+}
+
+func (m *captureTestMM) StartVMCapture(...mm.Option) error {
+	m.startCalls++
+
+	return m.startErr
+}
+
+func (m *captureTestMM) StopVMCapture(...mm.Option) error {
+	m.stopCalls++
+
+	return m.stopErr
+}
+
+// installCaptureTestMM installs the given fake as mm.DefaultMM for the
+// duration of the test, restoring the original afterward.
+func installCaptureTestMM(t *testing.T, fake *captureTestMM) {
+	t.Helper()
+
+	original := mm.DefaultMM
+	t.Cleanup(func() { mm.DefaultMM = original }) //nolint:reassign // restore test double
+
+	mm.DefaultMM = fake //nolint:reassign // install test double
+}
+
+// getCaptureTestExperiment builds a store mock backing a running experiment
+// (i.e. one with a non-empty status start time) named "test-experiment" with
+// a single VM named "test-vm" that has one network interface per entry in
+// networks. baseDir is used as the experiment's base directory so that any
+// directories phenix creates during the test (e.g. for captures) land in a
+// temporary location instead of the default "/phenix/..." path.
+func getCaptureTestExperiment(t *testing.T, networks []string, baseDir string) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	interfaces := make([]map[string]any, len(networks))
+	for i, vlan := range networks {
+		interfaces[i] = map[string]any{
+			"name": vlan,
+			"vlan": vlan,
+		}
+	}
+
+	c := store.Config{
+		Version: "phenix.sandia.gov/v1",
+		Kind:    "Experiment",
+		Metadata: store.ConfigMetadata{
+			Name: "test-experiment",
+		},
+		Spec: map[string]any{
+			"experimentName": "test-experiment",
+			"baseDir":        baseDir,
+			"topology": map[string]any{
+				"nodes": []map[string]any{
+					{
+						"type": "VirtualMachine",
+						"general": map[string]any{
+							"hostname":    "test-vm",
+							"do_not_boot": false,
+							"snapshot":    false,
+						},
+						"hardware": map[string]any{
+							"vcpus":   2,
+							"memory":  512,
+							"os_type": "linux",
+							"drives": []map[string]any{
+								{
+									"image":            "test.qc2",
+									"inject_partition": 1,
+								},
+							},
+						},
+						"network": map[string]any{
+							"interfaces": interfaces,
+						},
+					},
+				},
+			},
+		},
+		Status: map[string]any{
+			"startTime": "2024-01-01T00:00:00Z",
+		},
+	}
+
+	m := store.NewMockStore(ctrl)
+	m.EXPECT().Get(gomock.Any()).DoAndReturn(func(cfg *store.Config) error {
+		*cfg = c
+
+		return nil
+	}).AnyTimes()
+
+	store.DefaultStore = m //nolint:reassign // monkey patching for test
+}
+
+// ---------------------------------------------------------------------------
+// StartCapture
+// ---------------------------------------------------------------------------
+
+func TestStartCaptureMissingExperimentName(t *testing.T) {
+	if err := vm.StartCapture("", "test-vm", 0, "out.pcap"); err == nil {
+		t.Fatal("expected error for missing experiment name")
+	}
+}
+
+func TestStartCaptureMissingVMName(t *testing.T) {
+	if err := vm.StartCapture("test-experiment", "", 0, "out.pcap"); err == nil {
+		t.Fatal("expected error for missing VM name")
+	}
+}
+
+func TestStartCaptureMissingOutputFile(t *testing.T) {
+	if err := vm.StartCapture("test-experiment", "test-vm", 0, ""); err == nil {
+		t.Fatal("expected error for missing output file")
+	}
+}
+
+func TestStartCaptureVMNotRunning(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{{Name: "test-vm", Running: false, Networks: []string{"EXP_1"}}},
+	}
+	installCaptureTestMM(t, fake)
+
+	err := vm.StartCapture("test-experiment", "test-vm", 0, "out.pcap")
+	if err == nil {
+		t.Fatal("expected error when VM is not running")
+	}
+
+	if fake.startCalls != 0 {
+		t.Fatalf("expected StartVMCapture to not be called, got %d calls", fake.startCalls)
+	}
+}
+
+func TestStartCaptureInvalidInterfaceIndex(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1"}, t.TempDir())
+
+	fake := &captureTestMM{vmInfo: mm.VMs{{Name: "test-vm", Running: true, Networks: []string{"EXP_1"}}}}
+	installCaptureTestMM(t, fake)
+
+	for _, iface := range []int{-1, 1, 5} {
+		err := vm.StartCapture("test-experiment", "test-vm", iface, "out.pcap")
+		if err == nil {
+			t.Fatalf("expected error for out-of-range interface index %d", iface)
+		}
+	}
+
+	if fake.startCalls != 0 {
+		t.Fatalf("expected StartVMCapture to not be called, got %d calls", fake.startCalls)
+	}
+}
+
+func TestStartCaptureDisconnectedInterface(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"disconnected"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{{Name: "test-vm", Running: true, Networks: []string{"disconnected"}}},
+	}
+	installCaptureTestMM(t, fake)
+
+	err := vm.StartCapture("test-experiment", "test-vm", 0, "out.pcap")
+	if err == nil {
+		t.Fatal("expected error when capturing on a disconnected interface")
+	}
+
+	if fake.startCalls != 0 {
+		t.Fatalf("expected StartVMCapture to not be called, got %d calls", fake.startCalls)
+	}
+}
+
+func TestStartCaptureSuccess(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{{Name: "test-vm", Running: true, Networks: []string{"EXP_1", "EXP_2"}}},
+	}
+	installCaptureTestMM(t, fake)
+
+	if err := vm.StartCapture("test-experiment", "test-vm", 1, "out"); err != nil {
+		t.Fatalf("unexpected error starting capture: %v", err)
+	}
+
+	if fake.startCalls != 1 {
+		t.Fatalf("expected StartVMCapture to be called once, got %d calls", fake.startCalls)
+	}
+}
+
+func TestStartCapturePropagatesMinimegaError(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1"}, t.TempDir())
+
+	wantErr := errors.New("boom")
+
+	fake := &captureTestMM{
+		vmInfo:   mm.VMs{{Name: "test-vm", Running: true, Networks: []string{"EXP_1"}}},
+		startErr: wantErr,
+	}
+	installCaptureTestMM(t, fake)
+
+	err := vm.StartCapture("test-experiment", "test-vm", 0, "out.pcap")
+	if err == nil {
+		t.Fatal("expected error to be propagated")
+	}
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped error %v, got %v", wantErr, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StopCaptures (all interfaces)
+// ---------------------------------------------------------------------------
+
+func TestStopCapturesMissingExperimentName(t *testing.T) {
+	if err := vm.StopCaptures("", "test-vm"); err == nil {
+		t.Fatal("expected error for missing experiment name")
+	}
+}
+
+func TestStopCapturesMissingVMName(t *testing.T) {
+	if err := vm.StopCaptures("test-experiment", ""); err == nil {
+		t.Fatal("expected error for missing VM name")
+	}
+}
+
+func TestStopCapturesNoCapturesRunning(t *testing.T) {
+	fake := new(captureTestMM)
+	installCaptureTestMM(t, fake)
+
+	err := vm.StopCaptures("test-experiment", "test-vm")
+	if !errors.Is(err, vm.ErrNoCaptures) {
+		t.Fatalf("expected ErrNoCaptures, got %v", err)
+	}
+
+	if fake.stopCalls != 0 {
+		t.Fatalf("expected StopVMCapture to not be called, got %d calls", fake.stopCalls)
+	}
+}
+
+func TestStopCapturesStopsAllInterfaces(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		captures: []mm.Capture{
+			{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"},
+			{VM: "test-vm", Interface: 1, Filepath: "/tmp/1.pcap"},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	if err := vm.StopCaptures("test-experiment", "test-vm"); err != nil {
+		t.Fatalf("unexpected error stopping captures: %v", err)
+	}
+
+	if fake.stopCalls != 1 {
+		t.Fatalf("expected StopVMCapture to be called once, got %d calls", fake.stopCalls)
+	}
+}
+
+func TestStopCapturesPropagatesMinimegaError(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1"}, t.TempDir())
+
+	wantErr := errors.New("boom")
+
+	fake := &captureTestMM{
+		captures: []mm.Capture{{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"}},
+		stopErr:  wantErr,
+	}
+	installCaptureTestMM(t, fake)
+
+	err := vm.StopCaptures("test-experiment", "test-vm")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped error %v, got %v", wantErr, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StopCapture (single interface)
+// ---------------------------------------------------------------------------
+
+func TestStopCaptureMissingExperimentName(t *testing.T) {
+	if err := vm.StopCapture("", "test-vm", 0); err == nil {
+		t.Fatal("expected error for missing experiment name")
+	}
+}
+
+func TestStopCaptureMissingVMName(t *testing.T) {
+	if err := vm.StopCapture("test-experiment", "", 0); err == nil {
+		t.Fatal("expected error for missing VM name")
+	}
+}
+
+func TestStopCaptureNegativeInterface(t *testing.T) {
+	if err := vm.StopCapture("test-experiment", "test-vm", -1); err == nil {
+		t.Fatal("expected error for negative interface index")
+	}
+}
+
+func TestStopCaptureNoCapturesRunning(t *testing.T) {
+	fake := new(captureTestMM)
+	installCaptureTestMM(t, fake)
+
+	err := vm.StopCapture("test-experiment", "test-vm", 0)
+	if !errors.Is(err, vm.ErrNoCaptures) {
+		t.Fatalf("expected ErrNoCaptures, got %v", err)
+	}
+
+	if fake.stopCalls != 0 {
+		t.Fatalf("expected StopVMCapture to not be called, got %d calls", fake.stopCalls)
+	}
+}
+
+// TestStopCaptureInterfaceNotCaptured verifies that requesting to stop a
+// capture on an interface that isn't currently being captured returns
+// ErrNoCaptures and does not touch the captures running on other interfaces
+// of the same VM.
+func TestStopCaptureInterfaceNotCaptured(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		captures: []mm.Capture{{VM: "test-vm", Interface: 1, Filepath: "/tmp/1.pcap"}},
+	}
+	installCaptureTestMM(t, fake)
+
+	err := vm.StopCapture("test-experiment", "test-vm", 0)
+	if !errors.Is(err, vm.ErrNoCaptures) {
+		t.Fatalf("expected ErrNoCaptures, got %v", err)
+	}
+
+	if fake.stopCalls != 0 {
+		t.Fatalf(
+			"expected StopVMCapture to not be called when the requested interface isn't captured, got %d calls",
+			fake.stopCalls,
+		)
+	}
+}
+
+// TestStopCaptureStopsOnlyRequestedInterface verifies that, when multiple
+// captures are running for a VM, requesting to stop just one interface's
+// capture succeeds without erroring about the other running captures. This
+// exercises the new minimega "capture pcap delete vm <name> <iface>"
+// behavior (sandia-minimega/minimega#1632) which allows stopping a single
+// interface's capture in isolation.
+func TestStopCaptureStopsOnlyRequestedInterface(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		captures: []mm.Capture{
+			{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"},
+			{VM: "test-vm", Interface: 1, Filepath: "/tmp/1.pcap"},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	if err := vm.StopCapture("test-experiment", "test-vm", 1); err != nil {
+		t.Fatalf("unexpected error stopping capture on interface 1: %v", err)
+	}
+
+	if fake.stopCalls != 1 {
+		t.Fatalf("expected StopVMCapture to be called once, got %d calls", fake.stopCalls)
+	}
+}
+
+func TestStopCapturePropagatesMinimegaError(t *testing.T) {
+	getCaptureTestExperiment(t, []string{"EXP_1"}, t.TempDir())
+
+	wantErr := errors.New("boom")
+
+	fake := &captureTestMM{
+		captures: []mm.Capture{{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"}},
+		stopErr:  wantErr,
+	}
+	installCaptureTestMM(t, fake)
+
+	err := vm.StopCapture("test-experiment", "test-vm", 0)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped error %v, got %v", wantErr, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveInterface
+// ---------------------------------------------------------------------------
+
+// getNamedCaptureTestExperiment is like getCaptureTestExperiment, but lets
+// the interface name differ from its VLAN so that name-based resolution
+// tests aren't accidentally passing just because the name and VLAN happen to
+// match.
+func getNamedCaptureTestExperiment(t *testing.T, ifaceNames, vlans []string, baseDir string) {
+	t.Helper()
+
+	if len(ifaceNames) != len(vlans) {
+		t.Fatalf("ifaceNames and vlans must be the same length")
+	}
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	interfaces := make([]map[string]any, len(vlans))
+	for i, vlan := range vlans {
+		interfaces[i] = map[string]any{
+			"name": ifaceNames[i],
+			"vlan": vlan,
+		}
+	}
+
+	c := store.Config{
+		Version: "phenix.sandia.gov/v1",
+		Kind:    "Experiment",
+		Metadata: store.ConfigMetadata{
+			Name: "test-experiment",
+		},
+		Spec: map[string]any{
+			"experimentName": "test-experiment",
+			"baseDir":        baseDir,
+			"topology": map[string]any{
+				"nodes": []map[string]any{
+					{
+						"type": "VirtualMachine",
+						"general": map[string]any{
+							"hostname":    "test-vm",
+							"do_not_boot": false,
+							"snapshot":    false,
+						},
+						"hardware": map[string]any{
+							"vcpus":   2,
+							"memory":  512,
+							"os_type": "linux",
+							"drives": []map[string]any{
+								{
+									"image":            "test.qc2",
+									"inject_partition": 1,
+								},
+							},
+						},
+						"network": map[string]any{
+							"interfaces": interfaces,
+						},
+					},
+				},
+			},
+		},
+		Status: map[string]any{
+			"startTime": "2024-01-01T00:00:00Z",
+		},
+	}
+
+	m := store.NewMockStore(ctrl)
+	m.EXPECT().Get(gomock.Any()).DoAndReturn(func(cfg *store.Config) error {
+		*cfg = c
+
+		return nil
+	}).AnyTimes()
+
+	store.DefaultStore = m //nolint:reassign // monkey patching for test
+}
+
+func TestResolveInterfaceNilVM(t *testing.T) {
+	if _, err := vm.ResolveInterface(nil, "0"); err == nil {
+		t.Fatal("expected error for nil VM")
+	}
+}
+
+func TestResolveInterfaceEmptyIdentifier(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0"}, []string{"EXP_1"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{{Name: "test-vm", Running: true, Networks: []string{"EXP_1"}}},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	if _, err := vm.ResolveInterface(v, ""); err == nil {
+		t.Fatal("expected error for empty interface identifier")
+	}
+}
+
+func TestResolveInterfaceByIndex(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0", "IF1"}, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{{Name: "test-vm", Running: true, Networks: []string{"EXP_1", "EXP_2"}}},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	idx, err := vm.ResolveInterface(v, "1")
+	if err != nil {
+		t.Fatalf("unexpected error resolving interface by index: %v", err)
+	}
+
+	if idx != 1 {
+		t.Fatalf("expected index 1, got %d", idx)
+	}
+}
+
+func TestResolveInterfaceIndexOutOfRange(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0"}, []string{"EXP_1"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{{Name: "test-vm", Running: true, Networks: []string{"EXP_1"}}},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	for _, idx := range []string{"-1", "1", "5"} {
+		if _, err := vm.ResolveInterface(v, idx); err == nil {
+			t.Fatalf("expected error for out-of-range index %q", idx)
+		}
+	}
+}
+
+func TestResolveInterfaceByName(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0", "IF1"}, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	idx, err := vm.ResolveInterface(v, "IF1")
+	if err != nil {
+		t.Fatalf("unexpected error resolving interface by name: %v", err)
+	}
+
+	if idx != 1 {
+		t.Fatalf("expected index 1, got %d", idx)
+	}
+}
+
+// TestResolveInterfaceByNameCaseInsensitive verifies that interface name
+// matching ignores case, since minimega/topology names aren't guaranteed to
+// be typed with consistent casing by users at the CLI.
+func TestResolveInterfaceByNameCaseInsensitive(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0", "IF1"}, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	idx, err := vm.ResolveInterface(v, "if1")
+	if err != nil {
+		t.Fatalf("unexpected error resolving interface by name: %v", err)
+	}
+
+	if idx != 1 {
+		t.Fatalf("expected index 1, got %d", idx)
+	}
+}
+
+func TestResolveInterfaceUnknownName(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0", "IF1"}, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	if _, err := vm.ResolveInterface(v, "bogus-iface"); err == nil {
+		t.Fatal("expected error for unknown interface name")
+	}
+}
+
+// TestResolveInterfaceByNameWhenMinimegaReordersInterfaces is a regression
+// test verifying that interface names remain correctly aligned with their
+// interface index even when minimega reports the VM's networks in a
+// different order than they were declared in the topology. minimega is the
+// source of truth for interface ordering on a running VM (see the ordering
+// note on api/vm/vm.go's `List`/`Get`), so `vm.Get` must reconcile
+// `IfaceNames` against that minimega-reported order rather than leaving it
+// in topology-declaration order.
+func TestResolveInterfaceByNameWhenMinimegaReordersInterfaces(t *testing.T) {
+	// Topology declares IF0/EXP_1 then IF1/EXP_2, but minimega reports the
+	// VM's networks in the opposite order.
+	getNamedCaptureTestExperiment(t, []string{"IF0", "IF1"}, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_2 (102)", "EXP_1 (101)"}},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	wantIfaceNames := []string{"IF1", "IF0"}
+	if !reflect.DeepEqual(v.IfaceNames, wantIfaceNames) {
+		t.Fatalf("expected IfaceNames %v to be reordered to match minimega's Networks %v, got %v", wantIfaceNames, v.Networks, v.IfaceNames)
+	}
+
+	// IF0 is declared first in the topology, but minimega reports it second
+	// (index 1) for this VM, so resolving by name must return 1, not 0.
+	idx, err := vm.ResolveInterface(v, "IF0")
+	if err != nil {
+		t.Fatalf("unexpected error resolving interface by name: %v", err)
+	}
+
+	if idx != 1 {
+		t.Fatalf("expected IF0 to resolve to index 1 (minimega's order), got %d", idx)
+	}
+
+	idx, err = vm.ResolveInterface(v, "IF1")
+	if err != nil {
+		t.Fatalf("unexpected error resolving interface by name: %v", err)
+	}
+
+	if idx != 0 {
+		t.Fatalf("expected IF1 to resolve to index 0 (minimega's order), got %d", idx)
+	}
+}
+
+// TestStartCaptureByInterfaceName is an end-to-end (within the vm package)
+// check that StartCapture works when combined with ResolveInterface to
+// support specifying an interface by name, mirroring how the CLI layer uses
+// these two functions together.
+func TestStartCaptureByInterfaceName(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0", "IF1"}, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	idx, err := vm.ResolveInterface(v, "IF1")
+	if err != nil {
+		t.Fatalf("unexpected error resolving interface by name: %v", err)
+	}
+
+	if err := vm.StartCapture("test-experiment", "test-vm", idx, "out.pcap"); err != nil {
+		t.Fatalf("unexpected error starting capture: %v", err)
+	}
+
+	if fake.startCalls != 1 {
+		t.Fatalf("expected StartVMCapture to be called once, got %d calls", fake.startCalls)
+	}
+}
+
+// TestStartCaptureForVMSkipsRedundantLookup verifies that StartCaptureForVM
+// uses the caller-provided VM details directly instead of re-fetching them,
+// so callers that already resolved the VM (e.g. to resolve an interface name
+// via ResolveInterface) don't pay for a second lookup.
+func TestStartCaptureForVMSkipsRedundantLookup(t *testing.T) {
+	getNamedCaptureTestExperiment(t, []string{"IF0", "IF1"}, []string{"EXP_1", "EXP_2"}, t.TempDir())
+
+	fake := &captureTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+	}
+	installCaptureTestMM(t, fake)
+
+	v, err := vm.Get("test-experiment", "test-vm")
+	if err != nil {
+		t.Fatalf("unexpected error getting VM: %v", err)
+	}
+
+	// Zero out the fake's GetVMInfo results so any *additional* call to
+	// vm.Get (which calls mm.GetVMInfo) would cause StartCaptureForVM to see
+	// no VM details and fail with a different error than expected below,
+	// proving StartCaptureForVM doesn't call Get again internally.
+	fake.vmInfo = nil
+
+	if err := vm.StartCaptureForVM(v, "test-experiment", "test-vm", 1, "out.pcap"); err != nil {
+		t.Fatalf("unexpected error starting capture via pre-fetched VM: %v", err)
+	}
+
+	if fake.startCalls != 1 {
+		t.Fatalf("expected StartVMCapture to be called once, got %d calls", fake.startCalls)
+	}
+}
+
+func TestStartCaptureForVMNilVM(t *testing.T) {
+	if err := vm.StartCaptureForVM(nil, "test-experiment", "test-vm", 0, "out.pcap"); err == nil {
+		t.Fatal("expected error for nil VM")
+	}
+}

--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -113,12 +113,16 @@ func List(expName string) ([]mm.VM, error) { //nolint:funlen // complex logic
 			Tags:            node.Labels(),
 		}
 
+		ifaceNameByVLAN := make(map[string]string)
+
 		for _, iface := range node.Network().Interfaces() {
 			vm.IPv4 = append(vm.IPv4, iface.Address()) // empty for DHCP
 
 			if iface.VLAN() != "" { // might be empty for external nodes
 				vm.Networks = append(vm.Networks, iface.VLAN())
+				vm.IfaceNames = append(vm.IfaceNames, iface.Name())
 				vm.Interfaces[iface.VLAN()] = iface.Address() // empty for DHCP
+				ifaceNameByVLAN[iface.VLAN()] = iface.Name()
 			}
 		}
 
@@ -151,25 +155,35 @@ func List(expName string) ([]mm.VM, error) { //nolint:funlen // complex logic
 				vm.IPv4 = make([]string, len(details.Networks))
 			}
 
+			// minimega is the source of truth for interface ordering in a running
+			// experiment, so rebuild `vm.IfaceNames` to match `details.Networks`
+			// instead of leaving it in the (possibly different) order the
+			// interfaces were declared in the topology.
+			vm.IfaceNames = make([]string, len(details.Networks))
+
 			// Since we get the IP from the experiment config, but the network name
 			// from minimega (to preserve iface to network ordering), make sure the
 			// ordering of IPs matches the odering of networks. We could just use a
 			// map here, but then the iface to network ordering that minimega ensures
 			// would be lost.
 			for i, nw := range details.Networks {
-				// If it's set here, we got it from minimega, which is the source of truth
-				// for running experiments.
-				if vm.IPv4[i] != "" {
-					continue
-				}
-
 				// At this point, `nw` will look something like `EXP_1 (101)`. In the
 				// experiment config, we just have `EXP_1` so we need to use that
-				// portion from minimega as the `Interfaces` map key.
-				if match := vlanAliasRegex.FindStringSubmatch(nw); match != nil {
-					vm.IPv4[i] = vm.Interfaces[match[1]]
-				} else {
-					vm.IPv4[i] = "n/a"
+				// portion from minimega as the `Interfaces`/`ifaceNameByVLAN` map key.
+				match := vlanAliasRegex.FindStringSubmatch(nw)
+
+				// If it's set here, we got it from minimega, which is the source of truth
+				// for running experiments.
+				if vm.IPv4[i] == "" {
+					if match != nil {
+						vm.IPv4[i] = vm.Interfaces[match[1]]
+					} else {
+						vm.IPv4[i] = "n/a"
+					}
+				}
+
+				if match != nil {
+					vm.IfaceNames[i] = ifaceNameByVLAN[match[1]]
 				}
 			}
 		default:
@@ -186,7 +200,7 @@ func List(expName string) ([]mm.VM, error) { //nolint:funlen // complex logic
 // name. If the experiment is running, topology VM settings are combined with
 // running VM details. It returns a pointer to a VM struct, and any errors
 // encountered while retrieving the VM.
-func Get(expName, vmName string) (*mm.VM, error) {
+func Get(expName, vmName string) (*mm.VM, error) { //nolint:funlen // complex logic
 	if expName == "" {
 		return nil, errors.New("no experiment name provided")
 	}
@@ -200,7 +214,10 @@ func Get(expName, vmName string) (*mm.VM, error) {
 		return nil, fmt.Errorf("getting experiment %s: %w", expName, err)
 	}
 
-	var vm *mm.VM
+	var (
+		vm              *mm.VM
+		ifaceNameByVLAN = make(map[string]string)
+	)
 
 	for idx, node := range exp.Spec.Topology().Nodes() {
 		if node.General().Hostname() != vmName {
@@ -229,7 +246,9 @@ func Get(expName, vmName string) (*mm.VM, error) {
 		for _, iface := range node.Network().Interfaces() {
 			vm.IPv4 = append(vm.IPv4, iface.Address()) // empty for DHCP
 			vm.Networks = append(vm.Networks, iface.VLAN())
+			vm.IfaceNames = append(vm.IfaceNames, iface.Name())
 			vm.Interfaces[iface.VLAN()] = iface.Address() // empty for DHCP
+			ifaceNameByVLAN[iface.VLAN()] = iface.Name()
 		}
 
 		for _, app := range exp.Apps() {
@@ -277,24 +296,34 @@ func Get(expName, vmName string) (*mm.VM, error) {
 		vm.IPv4 = make([]string, len(details[0].Networks))
 	}
 
+	// minimega is the source of truth for interface ordering in a running
+	// experiment, so rebuild `vm.IfaceNames` to match `details[0].Networks`
+	// instead of leaving it in the (possibly different) order the interfaces
+	// were declared in the topology.
+	vm.IfaceNames = make([]string, len(details[0].Networks))
+
 	// Since we get the IP from the experiment config, but the network name from
 	// minimega (to preserve iface to network ordering), make sure the ordering of
 	// IPs matches the odering of networks. We could just use a map here, but then
 	// the iface to network ordering that minimega ensures would be lost.
 	for idx, nw := range details[0].Networks {
-		// If it's set here, we got it from minimega, which is the source of truth
-		// for running experiments.
-		if vm.IPv4[idx] != "" {
-			continue
-		}
-
 		// At this point, `nw` will look something like `EXP_1 (101)`. In the exp,
 		// we just have `EXP_1` so we need to use that portion from minimega as the
-		// `Interfaces` map key.
-		if match := vlanAliasRegex.FindStringSubmatch(nw); match != nil {
-			vm.IPv4[idx] = vm.Interfaces[match[1]]
-		} else {
-			vm.IPv4[idx] = "n/a"
+		// `Interfaces`/`ifaceNameByVLAN` map key.
+		match := vlanAliasRegex.FindStringSubmatch(nw)
+
+		// If it's set here, we got it from minimega, which is the source of truth
+		// for running experiments.
+		if vm.IPv4[idx] == "" {
+			if match != nil {
+				vm.IPv4[idx] = vm.Interfaces[match[1]]
+			} else {
+				vm.IPv4[idx] = "n/a"
+			}
+		}
+
+		if match != nil {
+			vm.IfaceNames[idx] = ifaceNameByVLAN[match[1]]
 		}
 	}
 

--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -33,6 +33,7 @@ const (
 	startCaptureArgs       = 4
 	startSubnetArgs        = 2
 	stopCaptureArgs        = 2
+	stopCaptureIfaceArgs   = 3
 	stopSubnetArgs         = 2
 	stopAllArgs            = 1
 	memSnapArgs            = 3
@@ -921,28 +922,46 @@ func newVMCaptureCmd() *cobra.Command {
 	}
 
 	startVMCapture := &cobra.Command{
-		Use:               "start <experiment name> <vm name> <iface index> <output file>",
-		Short:             "Start a packet capture for a VM specifying the interface index and using given output file as name of capture file",
+		Use:               "start <experiment name> <vm name> <iface name/index> <output file>",
+		Short:             "Start a packet capture for a VM specifying the interface (by name or index) and using given output file as name of capture file",
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != startCaptureArgs {
 				return errors.New(
-					"must provide an experiment name, VM name, iface index, and output file",
+					"must provide an experiment name, VM name, iface name/index, and output file",
 				)
 			}
 
 			var (
-				expName = args[0]
-				vmName  = args[1]
-				out     = args[3]
+				expName  = args[0]
+				vmName   = args[1]
+				ifaceArg = args[2]
+				out      = args[3]
 			)
 
-			iface, err := strconv.Atoi(args[2])
+			v, err := vm.Get(expName, vmName)
 			if err != nil {
-				return errors.New("the network interface index must be an integer")
+				err := util.HumanizeError(
+					err,
+					"%s",
+					"Unable to get details for the "+vmName+" VM",
+				)
+
+				return err.Humanized()
 			}
 
-			if err := vm.StartCapture(expName, vmName, iface, out); err != nil {
+			iface, err := vm.ResolveInterface(v, ifaceArg)
+			if err != nil {
+				err := util.HumanizeError(
+					err,
+					"%s",
+					"Unable to resolve interface "+ifaceArg+" on the "+vmName+" VM",
+				)
+
+				return err.Humanized()
+			}
+
+			if err := vm.StartCaptureForVM(v, expName, vmName, iface, out); err != nil {
 				err := util.HumanizeError(
 					err,
 					"%s",
@@ -1037,18 +1056,74 @@ func newVMCaptureCmd() *cobra.Command {
 	}
 
 	stopVMCaptures := &cobra.Command{
-		Use:               "stop <experiment name> <vm name>",
-		Short:             "Stop all packet captures for the specified VM",
+		Use:   "stop <experiment name> <vm name> [iface name/index]",
+		Short: "Stop packet captures for the specified VM",
+		Long: `Stop packet captures for the specified VM
+
+  If an interface name or index is provided, only the packet capture running
+  on that interface is stopped, leaving any other running captures for the VM
+  untouched. Otherwise, all packet captures for the VM are stopped.`,
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != stopCaptureArgs {
-				return errors.New("must provide an experiment and VM name")
+			if len(args) != stopCaptureArgs && len(args) != stopCaptureIfaceArgs {
+				return errors.New(
+					"must provide an experiment name and VM name, and may optionally provide an iface name/index",
+				)
 			}
 
 			var (
 				expName = args[0]
 				vmName  = args[1]
 			)
+
+			if len(args) == stopCaptureIfaceArgs {
+				ifaceArg := args[2]
+
+				v, err := vm.Get(expName, vmName)
+				if err != nil {
+					err := util.HumanizeError(
+						err,
+						"%s",
+						"Unable to get details for the "+vmName+" VM",
+					)
+
+					return err.Humanized()
+				}
+
+				iface, err := vm.ResolveInterface(v, ifaceArg)
+				if err != nil {
+					err := util.HumanizeError(
+						err,
+						"%s",
+						"Unable to resolve interface "+ifaceArg+" on the "+vmName+" VM",
+					)
+
+					return err.Humanized()
+				}
+
+				if err := vm.StopCapture(expName, vmName, iface); err != nil {
+					err := util.HumanizeError(
+						err,
+						"%s",
+						"Unable to stop the packet capture on the "+vmName+" VM",
+					)
+
+					return err.Humanized()
+				}
+
+				plog.Info(
+					plog.TypeSystem,
+					"vm packet capture stopped",
+					"iface",
+					iface,
+					"vm",
+					vmName,
+					"exp",
+					expName,
+				)
+
+				return nil
+			}
 
 			err := vm.StopCaptures(expName, vmName)
 			if err != nil {

--- a/src/go/cmd/vm_capture_test.go
+++ b/src/go/cmd/vm_capture_test.go
@@ -1,0 +1,286 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/spf13/cobra"
+
+	"phenix/store"
+	"phenix/util/mm"
+)
+
+// findCaptureSubcommand looks up one of the "vm capture" subcommands (e.g.
+// "start" or "stop") by the first word of its Use string, so tests can
+// invoke its RunE directly without going through the full cobra command
+// tree.
+func findCaptureSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+
+	root := newVMCaptureCmd()
+
+	for _, sub := range root.Commands() {
+		if strings.Fields(sub.Use)[0] == name {
+			return sub
+		}
+	}
+
+	t.Fatalf("subcommand %q not found under vm capture", name)
+
+	return nil
+}
+
+// captureCmdTestMM is a test double for mm.MM used by the vm capture CLI
+// tests below. Embedding the (nil) mm.MM interface means any method call
+// this test doesn't stub will panic, which is fine since these tests only
+// ever exercise the capture-related methods.
+type captureCmdTestMM struct {
+	mm.MM
+
+	vmInfo   mm.VMs
+	captures []mm.Capture
+
+	startCalls int
+	stopCalls  int
+}
+
+func (m *captureCmdTestMM) GetVMInfo(...mm.Option) mm.VMs {
+	return m.vmInfo
+}
+
+func (m *captureCmdTestMM) GetVMCaptures(...mm.Option) []mm.Capture {
+	return m.captures
+}
+
+func (m *captureCmdTestMM) StartVMCapture(...mm.Option) error {
+	m.startCalls++
+
+	return nil
+}
+
+func (m *captureCmdTestMM) StopVMCapture(...mm.Option) error {
+	m.stopCalls++
+
+	return nil
+}
+
+// installCaptureCmdTestMM installs the given fake as mm.DefaultMM for the
+// duration of the test, restoring the original afterward.
+func installCaptureCmdTestMM(t *testing.T, fake *captureCmdTestMM) {
+	t.Helper()
+
+	original := mm.DefaultMM
+	t.Cleanup(func() { mm.DefaultMM = original }) //nolint:reassign // restore test double
+
+	mm.DefaultMM = fake //nolint:reassign // install test double
+}
+
+// installCaptureCmdTestExperiment builds a store mock backing a running
+// experiment named "test-experiment" with a single VM named "test-vm" that
+// has two network interfaces, named "IF0" and "IF1", on VLANs "EXP_1" and
+// "EXP_2" respectively. It installs the mock as store.DefaultStore for the
+// duration of the test.
+func installCaptureCmdTestExperiment(t *testing.T) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	c := store.Config{
+		Version: "phenix.sandia.gov/v1",
+		Kind:    "Experiment",
+		Metadata: store.ConfigMetadata{
+			Name: "test-experiment",
+		},
+		Spec: map[string]any{
+			"experimentName": "test-experiment",
+			"baseDir":        t.TempDir(),
+			"topology": map[string]any{
+				"nodes": []map[string]any{
+					{
+						"type": "VirtualMachine",
+						"general": map[string]any{
+							"hostname":    "test-vm",
+							"do_not_boot": false,
+							"snapshot":    false,
+						},
+						"hardware": map[string]any{
+							"vcpus":   2,
+							"memory":  512,
+							"os_type": "linux",
+							"drives": []map[string]any{
+								{
+									"image":            "test.qc2",
+									"inject_partition": 1,
+								},
+							},
+						},
+						"network": map[string]any{
+							"interfaces": []map[string]any{
+								{"name": "IF0", "vlan": "EXP_1"},
+								{"name": "IF1", "vlan": "EXP_2"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: map[string]any{
+			"startTime": "2024-01-01T00:00:00Z",
+		},
+	}
+
+	m := store.NewMockStore(ctrl)
+	m.EXPECT().Get(gomock.Any()).DoAndReturn(func(cfg *store.Config) error {
+		*cfg = c
+
+		return nil
+	}).AnyTimes()
+
+	store.DefaultStore = m //nolint:reassign // monkey patching for test
+}
+
+// These tests only exercise argument validation that happens before any
+// call into the vm API package, so they don't require a running experiment
+// or minimega instance.
+
+func TestVMCaptureStartRequiresFourArgs(t *testing.T) {
+	startCmd := findCaptureSubcommand(t, "start")
+
+	cases := [][]string{
+		nil,
+		{"exp"},
+		{"exp", "vm"},
+		{"exp", "vm", "0"},
+		{"exp", "vm", "0", "out.pcap", "extra"},
+	}
+
+	for _, args := range cases {
+		if err := startCmd.RunE(startCmd, args); err == nil {
+			t.Fatalf("expected error for args %v, got nil", args)
+		}
+	}
+}
+
+func TestVMCaptureStopRejectsWrongArgCount(t *testing.T) {
+	stopCmd := findCaptureSubcommand(t, "stop")
+
+	// Wrong number of args should fail before ever reaching the API layer.
+	// Note that 2 (experiment + VM) and 3 (experiment + VM + iface) args are
+	// both valid, so only counts outside that range are tested here.
+	cases := [][]string{
+		nil,
+		{"exp"},
+		{"exp", "vm", "0", "extra"},
+	}
+
+	for _, args := range cases {
+		if err := stopCmd.RunE(stopCmd, args); err == nil {
+			t.Fatalf("expected error for args %v, got nil", args)
+		}
+	}
+}
+
+// TestVMCaptureStartResolvesInterfaceByName verifies that the "start"
+// subcommand accepts an interface name (as declared in the topology) in
+// addition to a numeric index, and that it's correctly resolved to the
+// underlying interface index before calling into minimega.
+func TestVMCaptureStartResolvesInterfaceByName(t *testing.T) {
+	installCaptureCmdTestExperiment(t)
+
+	fake := &captureCmdTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+	}
+	installCaptureCmdTestMM(t, fake)
+
+	startCmd := findCaptureSubcommand(t, "start")
+
+	args := []string{"test-experiment", "test-vm", "IF1", "out.pcap"}
+	if err := startCmd.RunE(startCmd, args); err != nil {
+		t.Fatalf("unexpected error starting capture by interface name: %v", err)
+	}
+
+	if fake.startCalls != 1 {
+		t.Fatalf("expected StartVMCapture to be called once, got %d calls", fake.startCalls)
+	}
+}
+
+// TestVMCaptureStartUnknownInterfaceName verifies that an interface name
+// that doesn't match any interface declared in the topology produces an
+// error without ever calling into minimega.
+func TestVMCaptureStartUnknownInterfaceName(t *testing.T) {
+	installCaptureCmdTestExperiment(t)
+
+	fake := &captureCmdTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+	}
+	installCaptureCmdTestMM(t, fake)
+
+	startCmd := findCaptureSubcommand(t, "start")
+
+	err := startCmd.RunE(startCmd, []string{"test-experiment", "test-vm", "bogus-iface", "out.pcap"})
+	if err == nil {
+		t.Fatal("expected error for unknown interface name")
+	}
+
+	if fake.startCalls != 0 {
+		t.Fatalf("expected StartVMCapture to not be called, got %d calls", fake.startCalls)
+	}
+}
+
+// TestVMCaptureStopResolvesInterfaceByName mirrors
+// TestVMCaptureStartResolvesInterfaceByName for the "stop" subcommand.
+func TestVMCaptureStopResolvesInterfaceByName(t *testing.T) {
+	installCaptureCmdTestExperiment(t)
+
+	fake := &captureCmdTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+		captures: []mm.Capture{
+			{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"},
+			{VM: "test-vm", Interface: 1, Filepath: "/tmp/1.pcap"},
+		},
+	}
+	installCaptureCmdTestMM(t, fake)
+
+	stopCmd := findCaptureSubcommand(t, "stop")
+
+	if err := stopCmd.RunE(stopCmd, []string{"test-experiment", "test-vm", "IF1"}); err != nil {
+		t.Fatalf("unexpected error stopping capture by interface name: %v", err)
+	}
+
+	if fake.stopCalls != 1 {
+		t.Fatalf("expected StopVMCapture to be called once, got %d calls", fake.stopCalls)
+	}
+}
+
+func TestVMCaptureStopUnknownInterfaceName(t *testing.T) {
+	installCaptureCmdTestExperiment(t)
+
+	fake := &captureCmdTestMM{
+		vmInfo: mm.VMs{
+			{Name: "test-vm", Running: true, Networks: []string{"EXP_1 (101)", "EXP_2 (102)"}},
+		},
+		captures: []mm.Capture{
+			{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"},
+		},
+	}
+	installCaptureCmdTestMM(t, fake)
+
+	stopCmd := findCaptureSubcommand(t, "stop")
+
+	err := stopCmd.RunE(stopCmd, []string{"test-experiment", "test-vm", "bogus-iface"})
+	if err == nil {
+		t.Fatal("expected error for unknown interface name")
+	}
+
+	if fake.stopCalls != 0 {
+		t.Fatalf("expected StopVMCapture to not be called, got %d calls", fake.stopCalls)
+	}
+}

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -797,20 +797,52 @@ func (Minimega) StartVMCapture(opts ...Option) error {
 	return nil
 }
 
+// StopVMCapture stops packet captures for a VM. If the CaptureInterface
+// option is provided, only the capture running on that interface index is
+// stopped, leaving any other captures for the VM running. Otherwise, all
+// captures for the VM are stopped.
 func (Minimega) StopVMCapture(opts ...Option) error {
+	o := NewOptions(opts...)
+
 	captures := GetVMCaptures(opts...)
 
-	if len(captures) == 0 {
+	if o.captureIfaceSet {
+		var found bool
+
+		for _, capture := range captures {
+			if capture.Interface == o.captureIface {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return ErrNoCaptures
+		}
+	} else if len(captures) == 0 {
 		return ErrNoCaptures
 	}
 
-	o := NewOptions(opts...)
-
 	cmd := mmcli.NewNamespacedCommand(o.ns)
-	cmd.Command = "capture pcap delete vm " + o.vm
+
+	if o.captureIfaceSet {
+		cmd.Command = fmt.Sprintf("capture pcap delete vm %s %d", o.vm, o.captureIface)
+	} else {
+		cmd.Command = "capture pcap delete vm " + o.vm
+	}
 
 	err := mmcli.ErrorResponse(mmcli.Run(cmd))
 	if err != nil {
+		if o.captureIfaceSet {
+			return fmt.Errorf(
+				"deleting VM capture for interface %d on VM %s in namespace %s: %w",
+				o.captureIface,
+				o.vm,
+				o.ns,
+				err,
+			)
+		}
+
 		return fmt.Errorf("deleting VM captures for VM %s in namespace %s: %w", o.vm, o.ns, err)
 	}
 

--- a/src/go/util/mm/option.go
+++ b/src/go/util/mm/option.go
@@ -27,8 +27,9 @@ type options struct {
 	connectIface int
 	connectVLAN  string
 
-	captureIface int
-	captureFile  string
+	captureIface    int
+	captureIfaceSet bool
+	captureFile     string
 
 	screenshotSize string
 
@@ -123,6 +124,7 @@ func DisconnectInterface(i int) Option {
 func CaptureInterface(i int) Option {
 	return func(o *options) {
 		o.captureIface = i
+		o.captureIfaceSet = true
 	}
 }
 

--- a/src/go/util/mm/option_test.go
+++ b/src/go/util/mm/option_test.go
@@ -1,0 +1,45 @@
+package mm
+
+import "testing"
+
+// TestCaptureInterfaceSetsIfaceAndFlag verifies that the CaptureInterface
+// option records both the interface index and a flag indicating that an
+// interface was explicitly requested. This distinction is what lets
+// StopVMCapture tell the difference between "stop all captures for the VM"
+// and "stop only the capture on interface 0" (interface index 0 is also the
+// options struct's zero value).
+func TestCaptureInterfaceSetsIfaceAndFlag(t *testing.T) {
+	o := NewOptions(VMName("test-vm"), CaptureInterface(0))
+
+	if !o.captureIfaceSet {
+		t.Fatal("expected captureIfaceSet to be true after CaptureInterface(0)")
+	}
+
+	if o.captureIface != 0 {
+		t.Fatalf("expected captureIface to be 0, got %d", o.captureIface)
+	}
+}
+
+func TestCaptureInterfaceSetsNonZeroIface(t *testing.T) {
+	o := NewOptions(VMName("test-vm"), CaptureInterface(3))
+
+	if !o.captureIfaceSet {
+		t.Fatal("expected captureIfaceSet to be true after CaptureInterface(3)")
+	}
+
+	if o.captureIface != 3 {
+		t.Fatalf("expected captureIface to be 3, got %d", o.captureIface)
+	}
+}
+
+// TestNoCaptureInterfaceLeavesFlagUnset ensures that omitting the
+// CaptureInterface option (as when stopping all captures for a VM) leaves
+// captureIfaceSet false so callers can distinguish it from an explicit
+// request for interface 0.
+func TestNoCaptureInterfaceLeavesFlagUnset(t *testing.T) {
+	o := NewOptions(VMName("test-vm"))
+
+	if o.captureIfaceSet {
+		t.Fatal("expected captureIfaceSet to be false when CaptureInterface is not used")
+	}
+}

--- a/src/go/util/mm/types.go
+++ b/src/go/util/mm/types.go
@@ -239,6 +239,12 @@ type VM struct {
 	// ordering in the experiment database.
 	Interfaces map[string]string `json:"-"`
 
+	// IfaceNames holds the topology-declared name of each network
+	// interface, index-aligned with Networks. It's used internally to
+	// resolve a user-supplied interface name (as opposed to index) to the
+	// interface's index for operations like packet captures.
+	IfaceNames []string `json:"-"`
+
 	// Used internally for showing VM details.
 	Metadata    map[string]any `json:"-"`
 	Annotations map[string]any `json:"-"`
@@ -257,6 +263,9 @@ func (v VM) Copy() VM {
 
 	vm.Networks = make([]string, len(v.Networks))
 	copy(vm.Networks, v.Networks)
+
+	vm.IfaceNames = make([]string, len(v.IfaceNames))
+	copy(vm.IfaceNames, v.IfaceNames)
 
 	vm.Taps = make([]string, len(v.Taps))
 	copy(vm.Taps, v.Taps)

--- a/src/go/web/capture_test.go
+++ b/src/go/web/capture_test.go
@@ -1,0 +1,280 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+
+	"phenix/store"
+	v1 "phenix/types/version/v1"
+	"phenix/util/mm"
+	"phenix/web/middleware"
+	"phenix/web/rbac"
+)
+
+// captureHandlerTestMM is a test double for mm.MM used by the StopVMCaptures
+// handler tests. Embedding the (nil) mm.MM interface means any method call
+// this test doesn't stub will panic, which is fine since these tests only
+// ever exercise the capture-related methods.
+type captureHandlerTestMM struct {
+	mm.MM
+
+	vmInfo   mm.VMs
+	captures []mm.Capture
+
+	stopCalls int
+	stopErr   error
+}
+
+func (m *captureHandlerTestMM) GetVMInfo(...mm.Option) mm.VMs {
+	return m.vmInfo
+}
+
+func (m *captureHandlerTestMM) GetVMCaptures(...mm.Option) []mm.Capture {
+	return m.captures
+}
+
+func (m *captureHandlerTestMM) StopVMCapture(...mm.Option) error {
+	m.stopCalls++
+
+	return m.stopErr
+}
+
+// installCaptureHandlerTestMM installs the given fake as mm.DefaultMM for the
+// duration of the test, restoring the original afterward.
+func installCaptureHandlerTestMM(t *testing.T, fake *captureHandlerTestMM) {
+	t.Helper()
+
+	original := mm.DefaultMM
+	t.Cleanup(func() { mm.DefaultMM = original }) //nolint:reassign // restore test double
+
+	mm.DefaultMM = fake //nolint:reassign // install test double
+}
+
+// installCaptureHandlerTestExperiment builds a store mock backing a running
+// experiment (i.e. one with a non-empty status start time) named
+// "test-experiment" with a single VM named "test-vm" that has two network
+// interfaces on VLANs "EXP_1" and "EXP_2".
+func installCaptureHandlerTestExperiment(t *testing.T) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	c := store.Config{
+		Version: "phenix.sandia.gov/v1",
+		Kind:    "Experiment",
+		Metadata: store.ConfigMetadata{
+			Name: "test-experiment",
+		},
+		Spec: map[string]any{
+			"experimentName": "test-experiment",
+			"baseDir":        t.TempDir(),
+			"topology": map[string]any{
+				"nodes": []map[string]any{
+					{
+						"type": "VirtualMachine",
+						"general": map[string]any{
+							"hostname":    "test-vm",
+							"do_not_boot": false,
+							"snapshot":    false,
+						},
+						"hardware": map[string]any{
+							"vcpus":   2,
+							"memory":  512,
+							"os_type": "linux",
+							"drives": []map[string]any{
+								{
+									"image":            "test.qc2",
+									"inject_partition": 1,
+								},
+							},
+						},
+						"network": map[string]any{
+							"interfaces": []map[string]any{
+								{"name": "IF0", "vlan": "EXP_1"},
+								{"name": "IF1", "vlan": "EXP_2"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: map[string]any{
+			"startTime": "2024-01-01T00:00:00Z",
+		},
+	}
+
+	m := store.NewMockStore(ctrl)
+	m.EXPECT().Get(gomock.Any()).DoAndReturn(func(cfg *store.Config) error {
+		*cfg = c
+
+		return nil
+	}).AnyTimes()
+
+	store.DefaultStore = m //nolint:reassign // monkey patching for test
+}
+
+// stopVMCapturesTestRequest builds a DELETE request for the StopVMCaptures
+// handler targeting "test-experiment"/"test-vm", with the given raw query
+// string (e.g. "iface=1"), pre-populated with mux vars and a permissive
+// rbac.Role in its context so the handler's role check passes.
+func stopVMCapturesTestRequest(rawQuery string) *http.Request {
+	url := "/api/v1/experiments/test-experiment/vms/test-vm/captures"
+	if rawQuery != "" {
+		url += "?" + rawQuery
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, url, nil)
+	req = mux.SetURLVars(req, map[string]string{"exp": "test-experiment", "name": "test-vm"})
+
+	role := rbac.Role{
+		Spec: &v1.RoleSpec{
+			Policies: []*v1.PolicySpec{
+				{
+					Resources:     []string{"vms/captures"},
+					ResourceNames: []string{"*/*"},
+					Verbs:         []string{"delete"},
+				},
+			},
+		},
+	}
+
+	ctx := context.WithValue(req.Context(), middleware.ContextKeyRole, role)
+	ctx = context.WithValue(ctx, middleware.ContextKeyUser, "test-user")
+
+	return req.WithContext(ctx)
+}
+
+// twoInterfaceVMInfo returns mm.VMs describing a single running VM
+// ("test-vm") with two network interfaces, matching the topology built by
+// installCaptureHandlerTestExperiment.
+func twoInterfaceVMInfo() mm.VMs {
+	return mm.VMs{
+		{
+			Name:     "test-vm",
+			Running:  true,
+			Networks: []string{"EXP_1 (101)", "EXP_2 (102)"},
+		},
+	}
+}
+
+func TestStopVMCapturesStopsAllWithoutIfaceQuery(t *testing.T) {
+	installCaptureHandlerTestExperiment(t)
+
+	fake := &captureHandlerTestMM{
+		vmInfo: twoInterfaceVMInfo(),
+		captures: []mm.Capture{
+			{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"},
+			{VM: "test-vm", Interface: 1, Filepath: "/tmp/1.pcap"},
+		},
+	}
+	installCaptureHandlerTestMM(t, fake)
+
+	rec := httptest.NewRecorder()
+	StopVMCaptures(rec, stopVMCapturesTestRequest(""))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if fake.stopCalls != 1 {
+		t.Fatalf("expected StopVMCapture to be called once, got %d calls", fake.stopCalls)
+	}
+}
+
+func TestStopVMCapturesStopsOnlyRequestedInterface(t *testing.T) {
+	installCaptureHandlerTestExperiment(t)
+
+	fake := &captureHandlerTestMM{
+		vmInfo: twoInterfaceVMInfo(),
+		captures: []mm.Capture{
+			{VM: "test-vm", Interface: 0, Filepath: "/tmp/0.pcap"},
+			{VM: "test-vm", Interface: 1, Filepath: "/tmp/1.pcap"},
+		},
+	}
+	installCaptureHandlerTestMM(t, fake)
+
+	rec := httptest.NewRecorder()
+	StopVMCaptures(rec, stopVMCapturesTestRequest("iface=1"))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if fake.stopCalls != 1 {
+		t.Fatalf("expected StopVMCapture to be called once, got %d calls", fake.stopCalls)
+	}
+}
+
+// TestStopVMCapturesUnrequestedInterfaceNotCaptured verifies that requesting
+// to stop a capture on an interface that isn't currently being captured
+// fails without calling into minimega, so it can't be confused with stopping
+// all captures.
+func TestStopVMCapturesUnrequestedInterfaceNotCaptured(t *testing.T) {
+	installCaptureHandlerTestExperiment(t)
+
+	fake := &captureHandlerTestMM{
+		vmInfo:   twoInterfaceVMInfo(),
+		captures: []mm.Capture{{VM: "test-vm", Interface: 1, Filepath: "/tmp/1.pcap"}},
+	}
+	installCaptureHandlerTestMM(t, fake)
+
+	rec := httptest.NewRecorder()
+	StopVMCaptures(rec, stopVMCapturesTestRequest("iface=0"))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if fake.stopCalls != 0 {
+		t.Fatalf(
+			"expected StopVMCapture to not be called when the requested interface isn't captured, got %d calls",
+			fake.stopCalls,
+		)
+	}
+}
+
+func TestStopVMCapturesRejectsNonIntegerIface(t *testing.T) {
+	installCaptureHandlerTestExperiment(t)
+
+	fake := &captureHandlerTestMM{vmInfo: twoInterfaceVMInfo()}
+	installCaptureHandlerTestMM(t, fake)
+
+	rec := httptest.NewRecorder()
+	StopVMCaptures(rec, stopVMCapturesTestRequest("iface=not-a-number"))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if fake.stopCalls != 0 {
+		t.Fatalf("expected StopVMCapture to not be called, got %d calls", fake.stopCalls)
+	}
+}
+
+// TestStopVMCapturesForbidden verifies the role check still applies to the
+// per-interface stop, not just the stop-all path.
+func TestStopVMCapturesForbidden(t *testing.T) {
+	req := stopVMCapturesTestRequest("iface=0")
+
+	// Replace the permissive role installed by stopVMCapturesTestRequest with
+	// one that has no policies (a non-nil Spec is required; Role.Allowed
+	// dereferences Spec.Policies directly rather than treating a nil Spec as
+	// "no policies").
+	noPolicies := rbac.Role{Spec: &v1.RoleSpec{}}
+
+	ctx := context.WithValue(req.Context(), middleware.ContextKeyRole, noPolicies)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	StopVMCaptures(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -2625,14 +2625,19 @@ func StartVMCapture(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// StopVMCaptures - DELETE /experiments/{exp}/vms/{name}/captures.
+// StopVMCaptures - DELETE /experiments/{exp}/vms/{name}/captures[?iface={iface}].
+//
+// If the iface query parameter is provided, only the packet capture running
+// on that interface is stopped, leaving any other running captures for the
+// VM untouched. Otherwise, all packet captures for the VM are stopped.
 func StopVMCaptures(w http.ResponseWriter, r *http.Request) {
 	var (
-		ctx  = r.Context()
-		role = middleware.RoleFromContext(ctx)
-		vars = mux.Vars(r)
-		exp  = vars["exp"]
-		name = vars["name"]
+		ctx      = r.Context()
+		role     = middleware.RoleFromContext(ctx)
+		vars     = mux.Vars(r)
+		exp      = vars["exp"]
+		name     = vars["name"]
+		ifaceStr = r.URL.Query().Get("iface")
 	)
 
 	if !role.Allowed("vms/captures", "delete", fmt.Sprintf("%s/%s", exp, name)) {
@@ -2652,7 +2657,34 @@ func StopVMCaptures(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := vm.StopCaptures(exp, name)
+	var (
+		err  error
+		body json.RawMessage
+	)
+
+	if ifaceStr == "" {
+		err = vm.StopCaptures(exp, name)
+	} else {
+		var iface int
+
+		iface, err = strconv.Atoi(ifaceStr)
+		if err != nil {
+			http.Error(w, "iface query parameter must be an integer", http.StatusBadRequest)
+
+			return
+		}
+
+		if err = vm.StopCapture(exp, name, iface); err == nil {
+			body, err = json.Marshal(map[string]int{"interface": iface})
+			if err != nil {
+				plog.Error(plog.TypeSystem, "marshaling capture stop result", "err", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+		}
+	}
+
 	if err != nil {
 		plog.Error(
 			plog.TypeSystem,
@@ -2661,6 +2693,8 @@ func StopVMCaptures(w http.ResponseWriter, r *http.Request) {
 			exp,
 			"name",
 			name,
+			"iface",
+			ifaceStr,
 			"err",
 			err,
 		)
@@ -2672,7 +2706,7 @@ func StopVMCaptures(w http.ResponseWriter, r *http.Request) {
 	broker.Broadcast(
 		bt.NewRequestPolicy("vms/captures", "delete", fmt.Sprintf("%s/%s", exp, name)),
 		bt.NewResource("experiment/vm/capture", fmt.Sprintf("%s/%s", exp, name), "stop"),
-		nil,
+		body,
 	)
 
 	user := middleware.UserFromContext(ctx)
@@ -2685,6 +2719,8 @@ func StopVMCaptures(w http.ResponseWriter, r *http.Request) {
 		exp,
 		"vm",
 		name,
+		"iface",
+		ifaceStr,
 	)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/js/src/utils/captures.js
+++ b/src/js/src/utils/captures.js
@@ -1,0 +1,26 @@
+// Computes the updated `captures` array for a VM after a packet-capture
+// "stop" broadcast is received over the websocket. If `result` includes an
+// `interface` field, only the capture entry for that interface is removed,
+// leaving any other running captures for the VM untouched (per-interface
+// stop). Otherwise, an empty array is returned (all captures were stopped).
+export function applyStopCaptureUpdate(captures, result) {
+  if (result && result.interface !== undefined) {
+    return (captures || []).filter((c) => c.interface !== result.interface);
+  }
+
+  return [];
+}
+
+// Returns true if the given interface currently has a running packet
+// capture.
+export function isInterfaceCapturing(captures, iface) {
+  return (captures || []).some((c) => c.interface === iface);
+}
+
+// Returns true if more than one packet capture is currently running for a
+// VM. Used to decide whether stopping a capture on a specific interface
+// should first prompt the user to choose between stopping just that
+// interface or all of the VM's running captures.
+export function hasMultipleCaptures(captures) {
+  return (captures || []).length > 1;
+}

--- a/src/js/src/views/experiment/RunningExperiment.vue
+++ b/src/js/src/views/experiment/RunningExperiment.vue
@@ -1511,6 +1511,11 @@
   import { formattingMixin } from '@/utils/formattingMixin.js';
   import { useErrorNotification } from '@/utils/errorNotif';
   import { partitionSnapshotVMNames } from '@/utils/vmSnapshot.js';
+  import {
+    applyStopCaptureUpdate,
+    isInterfaceCapturing,
+    hasMultipleCaptures,
+  } from '@/utils/captures.js';
   import externalImg from '@/assets/imgs/external.png';
   import notAvailableImg from '@/assets/imgs/not-available.png';
   import delayedImg from '@/assets/imgs/delayed.png';
@@ -2168,14 +2173,25 @@
               case 'stop': {
                 for (let i = 0; i < vms.length; i++) {
                   if (vms[i].name == vm[1]) {
-                    vms[i].captures = [];
+                    vms[i].captures = applyStopCaptureUpdate(
+                      vms[i].captures,
+                      msg.result,
+                    );
                     break;
                   }
                 }
 
+                this.experiment.vms = [...vms];
+
                 this.$buefy.toast.open({
                   message:
-                    'Packet capture was stopped for the ' + vm[1] + ' VM.',
+                    msg.result && msg.result.interface !== undefined
+                      ? 'Packet capture was stopped for interface ' +
+                        msg.result.interface +
+                        ' on the ' +
+                        vm[1] +
+                        ' VM.'
+                      : 'Packet capture was stopped for the ' + vm[1] + ' VM.',
                   type: 'is-success',
                 });
 
@@ -2901,6 +2917,44 @@
         }
       },
 
+      // stopVMCapture issues the DELETE request to stop packet capture(s) for
+      // a VM. If iface is provided, only that interface's capture is
+      // stopped; otherwise all captures for the VM are stopped.
+      stopVMCapture(vm, iface) {
+        this.isWaiting = true;
+
+        const params = iface === undefined ? {} : { iface: iface };
+
+        axiosInstance
+          .delete(
+            'experiments/' +
+              this.$route.params.id +
+              '/vms/' +
+              vm.name +
+              '/captures',
+            { params: params },
+          )
+          .then((response) => {
+            if (response.status == 204) {
+              let vms = this.experiment.vms;
+
+              for (let i = 0; i < vms.length; i++) {
+                if (vms[i].name == response.data.name) {
+                  vms[i] = response.data;
+                  break;
+                }
+              }
+
+              this.experiment.vms = [...vms];
+              this.isWaiting = false;
+            }
+          })
+          .catch((err) => {
+            useErrorNotification(err);
+            this.isWaiting = false;
+          });
+      },
+
       handlePcap(vm, iface) {
         var dateTime = new Date();
         var time =
@@ -2922,23 +2976,46 @@
               '/captures',
           )
           .then((response) => {
-            let captures = response.data.captures;
-            let capturing = false;
+            let captures = response.data.captures || [];
+            let capturing = isInterfaceCapturing(captures, iface);
 
-            if (captures) {
-              for (let i = 0; i < captures.length; i++) {
-                if (captures[i].interface === iface) {
-                  capturing = true;
-                  break;
-                }
-              }
-            }
-
-            if (capturing) {
+            if (capturing && hasMultipleCaptures(captures)) {
+              // More than one capture is currently running for this VM;
+              // let the user choose between stopping just this interface's
+              // capture or all of the VM's running captures.
               this.$buefy.dialog.confirm({
-                title: 'Stop All Packet Captures',
+                title: 'Stop Packet Capture',
                 message:
-                  'This will stop all packet captures for the ' +
+                  'The ' +
+                  vm.name +
+                  ' VM has multiple packet captures running. Stop the ' +
+                  'capture on interface ' +
+                  iface +
+                  ' only, or stop all packet captures for the VM?',
+                cancelText: 'Stop Interface ' + iface + ' Only',
+                confirmText: 'Stop All Captures',
+                type: 'is-danger',
+                hasIcon: true,
+                onConfirm: () => {
+                  this.stopVMCapture(vm);
+                },
+                onCancel: (trigger) => {
+                  // Only the "Stop Interface <iface> Only" button (as
+                  // opposed to dismissing the dialog via escape or clicking
+                  // outside of it, either of which should be a no-op) stops
+                  // this interface's capture.
+                  if (trigger === 'button') {
+                    this.stopVMCapture(vm, iface);
+                  }
+                },
+              });
+            } else if (capturing) {
+              this.$buefy.dialog.confirm({
+                title: 'Stop Packet Capture',
+                message:
+                  'This will stop the packet capture on interface ' +
+                  iface +
+                  ' for the ' +
                   vm.name +
                   ' VM.',
                 cancelText: 'Cancel',
@@ -2946,35 +3023,7 @@
                 type: 'is-danger',
                 hasIcon: true,
                 onConfirm: () => {
-                  this.isWaiting = true;
-
-                  axiosInstance
-                    .delete(
-                      'experiments/' +
-                        this.$route.params.id +
-                        '/vms/' +
-                        vm.name +
-                        '/captures',
-                    )
-                    .then((response) => {
-                      if (response.status == 204) {
-                        let vms = this.experiment.vms;
-
-                        for (let i = 0; i < vms.length; i++) {
-                          if (vms[i].name == response.data.name) {
-                            vms[i] = response.data;
-                            break;
-                          }
-                        }
-
-                        this.experiment.vms = [...vms];
-                        this.isWaiting = false;
-                      }
-                    })
-                    .catch((err) => {
-                      useErrorNotification(err);
-                      this.isWaiting = false;
-                    });
+                  this.stopVMCapture(vm, iface);
                 },
               });
             } else if (vm.networks[iface] == 'disconnected') {

--- a/src/js/test/captures.test.js
+++ b/src/js/test/captures.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+import {
+  applyStopCaptureUpdate,
+  isInterfaceCapturing,
+  hasMultipleCaptures,
+} from '@/utils/captures.js';
+
+describe('applyStopCaptureUpdate', () => {
+  const captures = [
+    { vm: 'test-vm', interface: 0, filename: 'iface0.pcap' },
+    { vm: 'test-vm', interface: 1, filename: 'iface1.pcap' },
+  ];
+
+  test('removes only the specified interface, leaving others untouched', () => {
+    expect(applyStopCaptureUpdate(captures, { interface: 0 })).toEqual([
+      { vm: 'test-vm', interface: 1, filename: 'iface1.pcap' },
+    ]);
+  });
+
+  test('clears all captures when no result is provided (stop-all)', () => {
+    expect(applyStopCaptureUpdate(captures, undefined)).toEqual([]);
+  });
+
+  test('clears all captures when result has no interface field', () => {
+    expect(applyStopCaptureUpdate(captures, {})).toEqual([]);
+  });
+
+  test('handles an empty/nil captures list without throwing', () => {
+    expect(applyStopCaptureUpdate(null, { interface: 0 })).toEqual([]);
+    expect(applyStopCaptureUpdate(undefined, { interface: 0 })).toEqual([]);
+    expect(applyStopCaptureUpdate([], { interface: 0 })).toEqual([]);
+  });
+
+  test('treats interface 0 as a valid, present value (not falsy/missing)', () => {
+    // Regression guard: interface index 0 must not be confused with "no
+    // interface field present" just because 0 is falsy.
+    expect(
+      applyStopCaptureUpdate(
+        [{ vm: 'test-vm', interface: 0, filename: 'iface0.pcap' }],
+        { interface: 0 },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('isInterfaceCapturing', () => {
+  const captures = [
+    { vm: 'test-vm', interface: 0, filename: 'iface0.pcap' },
+    { vm: 'test-vm', interface: 1, filename: 'iface1.pcap' },
+  ];
+
+  test('returns true when the interface has a running capture', () => {
+    expect(isInterfaceCapturing(captures, 1)).toBe(true);
+  });
+
+  test('returns false when the interface has no running capture', () => {
+    expect(isInterfaceCapturing(captures, 2)).toBe(false);
+  });
+
+  test('returns false for an empty/nil captures list', () => {
+    expect(isInterfaceCapturing([], 0)).toBe(false);
+    expect(isInterfaceCapturing(null, 0)).toBe(false);
+    expect(isInterfaceCapturing(undefined, 0)).toBe(false);
+  });
+
+  test('treats interface 0 as a valid, present value', () => {
+    expect(isInterfaceCapturing(captures, 0)).toBe(true);
+  });
+});
+
+describe('hasMultipleCaptures', () => {
+  test('returns false when zero or one captures are running', () => {
+    expect(hasMultipleCaptures([])).toBe(false);
+    expect(hasMultipleCaptures(null)).toBe(false);
+    expect(hasMultipleCaptures(undefined)).toBe(false);
+    expect(hasMultipleCaptures([{ interface: 0 }])).toBe(false);
+  });
+
+  test('returns true when more than one capture is running', () => {
+    expect(hasMultipleCaptures([{ interface: 0 }, { interface: 1 }])).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Description

- Adds `phenix vm capture start`/`stop` support for targeting a single VM network interface by **name** (as declared in the experiment topology, e.g. `IF0`) or index, 
- Adds the ability to stop a single interface's capture without affecting other captures running on the same VM. Previously, only all of the captures could be stopped for a VM, not individually by interface.
- Adds the same functionality to the UI

This depends on new functionality added to minimega in https://github.com/sandia-minimega/minimega/pull/1632, which adds an optional interface index to `capture pcap delete vm <name>`.

It also depends on a fix in https://github.com/sandia-minimega/minimega/pull/1660

## Related Issue
N/A

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

This has been tested manually with a test experiment, including starting and stopping captures on multiple interfaces on a VM, stopping all captures on a VM, and testing on the CLI.

This is good to merge after the fix in https://github.com/sandia-minimega/minimega/pull/1660 is merged.

### UI Screenshots

<img width="469" height="266" alt="image" src="https://github.com/user-attachments/assets/e9774a2b-3dd5-4104-8b3a-157834a0f041" />
