### PR TITLE
feat(soh): filter external HIL connections

### DIFF
--- a/src/js/src/views/StateOfHealth.vue
+++ b/src/js/src/views/StateOfHealth.vue
@@ -567,6 +567,14 @@
               >
             </div>
             <div class="column">
+              <b-radio
+                v-model="radioButton"
+                native-value="external"
+                type="is-light"
+                >External / HIL</b-radio
+              >
+            </div>
+            <div class="column">
               <b-button @click="resetNetwork" type="is-light"
                 >Refresh Network</b-button
               >


### PR DESCRIPTION
## Summary
- add an External / HIL filter to the SOH topology graph
- reuse existing external status filtering to isolate external nodes and VLAN connections

## Validation
- `npm test -- --run`
- `npm run build`

## Screenshot

<img width="612" height="512" alt="image" src="https://github.com/user-attachments/assets/fcfd5259-19ef-4d2c-9039-6cc3cf52dac7" />


Closes #281