### PR TITLE
fix(jit): fix JIT docker image

### DIFF
--- a/docker/jit/Dockerfile
+++ b/docker/jit/Dockerfile
@@ -8,20 +8,25 @@ FROM $PHENIX_IMG
 ARG PHENIX_REPO
 ARG PHENIX_BRANCH
 
-ENV NODE_VERSION 24.16.0
-
+# Install Node.js
+ENV NODE_VERSION=24.16.0
 RUN wget -O node.txz https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
   && tar -xJf node.txz -C /usr/local --strip-components=1 --no-same-owner && rm node.txz \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-RUN npm install -g @redocly/cli
+# Install Redocly CLI globally for building API docs
+RUN npm install -g @redocly/cli && npm cache clean --force
+
 RUN git clone --branch ${PHENIX_BRANCH} https://github.com/${PHENIX_REPO}.git /usr/local/src/phenix \
   && mkdir -p /opt/phenix/web \
   && cp -a /usr/local/src/phenix/src/go/web/public /opt/phenix/web
 
 WORKDIR /usr/local/src/phenix/src/js
+RUN npm ci --no-fund --no-audit && npm cache clean --force
+
+# API documentation
 WORKDIR /opt/phenix/web/public
-RUN npx @redocly/cli build-docs docs/openapi.yml -o docs/index.html --title 'phenix API'
+RUN redocly build-docs docs/openapi.yml -o docs/index.html --title 'phenix API'
 
 COPY phenix-ui-entrypoint.sh /phenix-ui-entrypoint.sh
 RUN  chmod +x /phenix-ui-entrypoint.sh

--- a/docker/jit/phenix-ui-entrypoint.sh
+++ b/docker/jit/phenix-ui-entrypoint.sh
@@ -15,15 +15,6 @@ start_time=$(date +%s)
 
 pushd /usr/local/src/phenix/src/js &> /dev/null
 
-npm ci &> /tmp/phenix-ui-install.log
-res=$?
-
-if [ $res -ne 0 ]; then
-  echo -e "\nthere was an error installing phenix UI dependencies\n"
-  cat /tmp/phenix-ui-install.log
-  exit $res
-fi
-
 VITE_BASE_PATH=$base VITE_AUTH=$auth npm run build &> /tmp/phenix-ui-build.log
 res=$?
 


### PR DESCRIPTION
# Fix JIT image

## Description
When starting the JIT image, it installs a bunch of NPM dependencies. This is a problem when there isn't Internet available. 

Root cause is probably the removal of `yarn` in the Vue 3 PM, specifically [this change](https://github.com/sandialabs/sceptre-phenix/pull/320/changes#diff-84a9ce822c773c5873e5b6a67665f66b794f7a29f1385b9c46a9d1ec6ea1beb1L23), and the addition of `npm ci` into the entrypoint script.

Additionally, the current docker image clones the repo, which makes it impossible to cache changes. Ideally, on subsequent rebuilds when developing the full set of packages don't need to be re-downloaded unless `packages.json` changed. So I'm going to attempt to order things properly so Docker layer cache invalidation works as intended.

## Related Issue

Issue: https://github.com/sandialabs/sceptre-phenix/issues/405

Vue 3 PR: https://github.com/sandialabs/sceptre-phenix/pull/320

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [ ] I have included no proprietary/sensitive information in my code. 
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes

Testing currently, leaving draft until working.

Also, believe it or not, but this is a pure 100% home-grown free-range human-made PR. For now.
