### PR TITLE
fix: update copyright years

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,7 +99,7 @@ LABEL org.opencontainers.image.authors="Sandia National Laboratories <emulytics@
   org.opencontainers.image.source="https://github.com/sandialabs/sceptre-phenix" \
   org.opencontainers.image.revision="${PHENIX_COMMIT}" \
   org.opencontainers.image.vendor="Sandia National Laboratories" \
-  org.opencontainers.image.licenses="GPL-3.0-or-later" \
+  org.opencontainers.image.licenses="GPL-3.0-only" \
   org.opencontainers.image.title="phenix" \
   org.opencontainers.image.description="phenix is an orchestration tool and GUI for Sandia's minimega platform"
 

--- a/src/js/src/components/AppFooter.vue
+++ b/src/js/src/components/AppFooter.vue
@@ -9,7 +9,7 @@ component.
     <div class="container is-fluid">
       <small>
         <p style="float: left; color: whitesmoke; padding-bottom: 16px">
-          Copyright &copy; <b>2019-2025 Sandia National Laboratories</b>. All
+          Copyright &copy; <b>2019-2026 Sandia National Laboratories</b>. All
           Rights Reserved.
         </p>
         <p style="float: right; color: whitesmoke">{{ version }}</p>


### PR DESCRIPTION
# fix: update copyright years

## Description
Updated the stale footer copyright year range and corrected the Docker image license metadata to match the repository's GPL-3.0-only declaration.

## Related Issue
N/A

## Type of Change
- [x] Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
This is a minimal legal metadata cleanup for the current year and license consistency.
