### PR TITLE
feat(tunneler): add local web interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.0]
 
+### Fixed
+- **Tunneler**:
+  - **Listener State Synchronization**: Centralized local listener tracking behind a synchronized manager to prevent concurrent map and state access.
+  - **Operation Reporting**: Return errors for unknown listeners and local port conflicts instead of reporting successful operations.
+  - **Argument Handling**: Reject malformed command arguments and Unix socket payloads without panicking.
+  - **Listener Moves**: Restore an active listener's original port when moving to a new port fails.
+  - **Listener IDs**: Maintain a direct ID index and prevent IDs from being reused during a tunneler session.
+  - **Listener Listing**: Return local listeners in deterministic ID order.
+  - **Duplicate Listeners**: Treat repeated listener creation events as idempotent without replacing active listeners.
+  - **Unix Socket Protocol**: Replace Gob messages with JSON and typed listener action payloads.
+
 ### Added
+- **Tunneler Web Interface**: Add a local web dashboard for listing, enabling, disabling, and moving listeners, with live WebSocket updates.
 - **CLI Command Aliases**: Added `exp del`, `exp trig`, `exp res`, `exp rec`, `image del`, `config del`, and `vm res`.
 - **Centralized Logging Architecture**: Implemented a unified logging system where phēnix core aggregates logs from internal services and external apps.
 - **Dynamic Configuration**: Integrated `viper` with `fsnotify` to allow hot-swapping of configuration settings (e.g., log levels) without restarting services.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ make install-dev # Install development and build dependencies
 make clean       # Clean build artifacts
 ```
 
+The `phenix-tunneler serve` command can provide a local web interface for
+listing and managing listeners. It is disabled by default; enable it with
+`--web-listen 127.0.0.1:8080`. The address can be changed with that option.
+
 ### Build
 
 To build the phēnix core services locally:

--- a/src/go/tunneler/client.go
+++ b/src/go/tunneler/client.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -14,8 +14,8 @@ import (
 type client struct {
 	conn net.Conn
 
-	enc *gob.Encoder
-	dec *gob.Decoder
+	enc *json.Encoder
+	dec *json.Decoder
 }
 
 func newClient() (*client, error) {
@@ -33,8 +33,8 @@ func newClient() (*client, error) {
 		return nil, fmt.Errorf("dialing phenix unix socket %s: %w", sockPath, err)
 	}
 
-	cli.enc = gob.NewEncoder(cli.conn)
-	cli.dec = gob.NewDecoder(cli.conn)
+	cli.enc = json.NewEncoder(cli.conn)
+	cli.dec = json.NewDecoder(cli.conn)
 
 	return cli, nil
 }
@@ -49,38 +49,27 @@ func (c client) getLocalListeners() (Listeners, error) {
 		Type: LISTENERS,
 	}
 
-	err := c.enc.Encode(msg)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
+	if err := c.roundTrip(&msg); err != nil {
+		return nil, err
 	}
 
-	err = c.dec.Decode(&msg)
-	if err != nil {
-		return nil, fmt.Errorf("receiving response: %w", err)
-	}
-
-	if payload, ok := msg.Payload.(Listeners); ok {
-		return payload, nil
-	} else {
+	var payload Listeners
+	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
 		return nil, errors.New("decoding listeners from response")
 	}
+
+	return payload, nil
 }
 
 func (c client) moveLocalListener(id, port int) error {
 	msg := Message{ //nolint:exhaustruct // partial initialization
 		MID:     int(rand.Uint64()), //nolint:gosec // weak random number generator
 		Type:    MOVE,
-		Payload: []int{id, port},
+		Payload: marshalPayload(listenerAction{ID: id, Port: port}),
 	}
 
-	err := c.enc.Encode(msg)
-	if err != nil {
-		return fmt.Errorf("sending request: %w", err)
-	}
-
-	err = c.dec.Decode(&msg)
-	if err != nil {
-		return fmt.Errorf("receiving response: %w", err)
+	if err := c.roundTrip(&msg); err != nil {
+		return err
 	}
 
 	if msg.Error != "" {
@@ -92,19 +81,15 @@ func (c client) moveLocalListener(id, port int) error {
 
 func (c client) activateLocalListener(id int) error {
 	msg := Message{ //nolint:exhaustruct // partial initialization
-		MID:     int(rand.Uint64()), //nolint:gosec // weak random number generator
-		Type:    ACTIVATE,
-		Payload: id,
+		MID:  int(rand.Uint64()), //nolint:gosec // weak random number generator
+		Type: ACTIVATE,
+		Payload: marshalPayload(
+			listenerAction{ID: id}, //nolint:exhaustruct // partial initialization
+		),
 	}
 
-	err := c.enc.Encode(msg)
-	if err != nil {
-		return fmt.Errorf("sending request: %w", err)
-	}
-
-	err = c.dec.Decode(&msg)
-	if err != nil {
-		return fmt.Errorf("receiving response: %w", err)
+	if err := c.roundTrip(&msg); err != nil {
+		return err
 	}
 
 	if msg.Error != "" {
@@ -116,19 +101,15 @@ func (c client) activateLocalListener(id int) error {
 
 func (c client) deactivateLocalListener(id int) error {
 	msg := Message{ //nolint:exhaustruct // partial initialization
-		MID:     int(rand.Uint64()), //nolint:gosec // weak random number generator
-		Type:    DEACTIVATE,
-		Payload: id,
+		MID:  int(rand.Uint64()), //nolint:gosec // weak random number generator
+		Type: DEACTIVATE,
+		Payload: marshalPayload(
+			listenerAction{ID: id}, //nolint:exhaustruct // partial initialization
+		),
 	}
 
-	err := c.enc.Encode(msg)
-	if err != nil {
-		return fmt.Errorf("sending request: %w", err)
-	}
-
-	err = c.dec.Decode(&msg)
-	if err != nil {
-		return fmt.Errorf("receiving response: %w", err)
+	if err := c.roundTrip(&msg); err != nil {
+		return err
 	}
 
 	if msg.Error != "" {
@@ -136,4 +117,21 @@ func (c client) deactivateLocalListener(id int) error {
 	}
 
 	return nil
+}
+
+func (c client) roundTrip(msg *Message) error {
+	if err := c.enc.Encode(msg); err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+
+	if err := c.dec.Decode(msg); err != nil {
+		return fmt.Errorf("receiving response: %w", err)
+	}
+
+	return nil
+}
+
+func marshalPayload(payload any) json.RawMessage {
+	data, _ := json.Marshal(payload)
+	return data
 }

--- a/src/go/tunneler/main.go
+++ b/src/go/tunneler/main.go
@@ -30,10 +30,6 @@ var (
 	httpCli = new(http.Client)  //nolint:gochecknoglobals // global state
 	headers = make(http.Header) //nolint:gochecknoglobals // global state
 
-	listenerIDs = make(chan int) //nolint:gochecknoglobals // global state
-	// key will be "<exp>:<vm>:<fwd host>:<dst port>".
-	listeners = make(map[string]*LocalListener) //nolint:gochecknoglobals // global state
-
 	username string //nolint:gochecknoglobals // global state
 )
 
@@ -69,6 +65,7 @@ by other users can be created manually using the 'activate' subcommand.
 var serveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 	Use:   "serve <url>",
 	Short: "Start local WebSocket proxy server",
+	Args:  cobra.ExactArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		origin = args[0]
@@ -210,12 +207,6 @@ var serveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 			return fmt.Errorf("dialing websocket (%s): %w", wsURL, err)
 		}
 
-		go func() { // start a goroutine to generate listener IDs
-			for id := 1; ; id++ {
-				listenerIDs <- id
-			}
-		}()
-
 		existing, err := getRemoteListeners()
 		if err != nil {
 			return fmt.Errorf("getting initial list of existing listeners: %w", err)
@@ -270,7 +261,7 @@ var serveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 						continue
 					}
 
-					if _, ok := listeners[payload["key"]]; ok {
+					if localListeners.hasKey(payload["key"]) {
 						deleteLocalListener(payload["key"])
 					}
 				}
@@ -282,6 +273,7 @@ var serveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 var listCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 	Use:   "list",
 	Short: "Show table of known port forwards",
+	Args:  cobra.NoArgs,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cli, err := newClient()
@@ -336,16 +328,17 @@ var listCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 var moveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 	Use:   "move <id> <port>",
 	Short: "Move listener to a different local port",
+	Args:  cobra.ExactArgs(2),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.Atoi(args[0])
+		id, err := parseListenerID(args[0])
 		if err != nil {
-			return fmt.Errorf("malformed listener ID provided (%s): %w", args[0], err)
+			return err
 		}
 
-		port, err := strconv.Atoi(args[1])
+		port, err := parseLocalPort(args[1])
 		if err != nil {
-			return fmt.Errorf("malformed listener port provided (%s): %w", args[1], err)
+			return err
 		}
 
 		cli, err := newClient()
@@ -368,11 +361,12 @@ var moveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 var activateCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 	Use:   "activate <id>",
 	Short: "Activate a local forward (start listening on local port)",
+	Args:  cobra.ExactArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.Atoi(args[0])
+		id, err := parseListenerID(args[0])
 		if err != nil {
-			return fmt.Errorf("malformed listener ID provided (%s): %w", args[0], err)
+			return err
 		}
 
 		cli, err := newClient()
@@ -395,11 +389,12 @@ var activateCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 var deactivateCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 	Use:   "deactivate <id>",
 	Short: "Dectivate a local forward (stop listening on local port)",
+	Args:  cobra.ExactArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.Atoi(args[0])
+		id, err := parseListenerID(args[0])
 		if err != nil {
-			return fmt.Errorf("malformed listener ID provided (%s): %w", args[0], err)
+			return err
 		}
 
 		cli, err := newClient()

--- a/src/go/tunneler/main.go
+++ b/src/go/tunneler/main.go
@@ -82,6 +82,11 @@ var serveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 			return errors.New("unable to get --auth-token flag")
 		}
 
+		webListen, err := cmd.Flags().GetString("web-listen")
+		if err != nil {
+			return errors.New("unable to get --web-listen flag")
+		}
+
 		u, err := url.Parse(origin)
 		if err != nil {
 			return fmt.Errorf("parsing URL: %w", err)
@@ -223,6 +228,14 @@ var serveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 			return fmt.Errorf("starting unix socket: %w", err)
 		}
 
+		if webListen != "" {
+			if err := startWebServer(webListen); err != nil {
+				return fmt.Errorf("starting web server: %w", err)
+			}
+
+			fmt.Printf("tunneler web interface available at http://%s\n", webListen) //nolint:forbidigo // CLI output
+		}
+
 		for {
 			var publish bt.Publish
 
@@ -328,7 +341,7 @@ var listCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 var moveCmd = &cobra.Command{ //nolint:gochecknoglobals // cobra command
 	Use:   "move <id> <port>",
 	Short: "Move listener to a different local port",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(2), //nolint:mnd // "magic number" documented above in usage
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id, err := parseListenerID(args[0])
@@ -418,6 +431,7 @@ func main() {
 	serveCmd.Flags().StringP("username", "u", "", "username to log into phēnix with")
 	serveCmd.Flags().StringP("auth-token", "t", "", "phēnix API token (skip login process)")
 	serveCmd.Flags().StringP("use-cookie", "c", "", "name of cookie to use for auth token")
+	serveCmd.Flags().StringP("web-listen", "w", "", "address for the local web interface (disabled by default)")
 
 	rootCmd.AddCommand(listCmd, activateCmd, deactivateCmd, moveCmd, serveCmd)
 

--- a/src/go/tunneler/manager.go
+++ b/src/go/tunneler/manager.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"errors"
+	"sort"
+	"sync"
+
+	ft "phenix/web/forward/forwardtypes"
+)
+
+var errListenerNotFound = errors.New("listener not found")
+
+type listenerManager struct {
+	mu        sync.RWMutex
+	listeners map[string]*LocalListener
+	byID      map[int]*LocalListener
+	nextID    int
+}
+
+func newListenerManager() *listenerManager {
+	return &listenerManager{
+		listeners: make(map[string]*LocalListener),
+		byID:      make(map[int]*LocalListener),
+	}
+}
+
+func (m *listenerManager) add(listener ft.Listener) (*LocalListener, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := listener.ToKey()
+
+	if existing, ok := m.listeners[key]; ok {
+		return existing, false
+	}
+
+	m.nextID++
+
+	local := &LocalListener{ID: m.nextID, Listener: listener} //nolint:exhaustruct // partial initialization
+
+	m.listeners[key] = local
+	m.byID[local.ID] = local
+
+	return local, true
+}
+
+func (m *listenerManager) snapshot() Listeners {
+	m.mu.RLock()
+
+	result := make(Listeners, 0, len(m.listeners))
+	for _, listener := range m.listeners {
+		result = append(result, *listener)
+	}
+
+	m.mu.RUnlock()
+
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
+
+	return result
+}
+
+func (m *listenerManager) hasKey(key string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, ok := m.listeners[key]
+
+	return ok
+}
+
+func (m *listenerManager) remove(key string) (int, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	listener, ok := m.listeners[key]
+	if !ok {
+		return 0, false
+	}
+
+	if listener.listener != nil {
+		_ = listener.listener.Close()
+	}
+
+	port := listener.SrcPort
+
+	delete(m.listeners, key)
+	delete(m.byID, listener.ID)
+
+	return port, true
+}
+
+func (m *listenerManager) withListener(id int, fn func(*LocalListener) error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	listener, ok := m.byID[id]
+	if ok {
+		return fn(listener)
+	}
+
+	return errListenerNotFound
+}
+
+// listenerManager is the sole owner of the process-local listener registry.
+// Listener IDs are session-scoped and are not persisted across restarts.
+var localListeners = newListenerManager() //nolint:gochecknoglobals // process-local state

--- a/src/go/tunneler/manager.go
+++ b/src/go/tunneler/manager.go
@@ -18,7 +18,7 @@ type listenerManager struct {
 }
 
 func newListenerManager() *listenerManager {
-	return &listenerManager{
+	return &listenerManager{ //nolint:exhaustruct // partial initialization
 		listeners: make(map[string]*LocalListener),
 		byID:      make(map[int]*LocalListener),
 	}

--- a/src/go/tunneler/manager_test.go
+++ b/src/go/tunneler/manager_test.go
@@ -43,7 +43,7 @@ func TestListenerManagerConcurrentAccess(t *testing.T) {
 		wg      sync.WaitGroup
 	)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(1)
 
 		go func(i int) {
@@ -75,7 +75,7 @@ func TestListenerManagerConcurrentAccess(t *testing.T) {
 		t.Errorf("snapshot length = %d, want 100", got)
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(1)
 
 		go func(i int) {
@@ -85,7 +85,7 @@ func TestListenerManagerConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(1)
 
 		go func(int) {
@@ -133,7 +133,7 @@ func TestListenerManagerSnapshotIsSorted(t *testing.T) {
 	manager.add(ft.Listener{Exp: "bar", VM: "vm", DstHost: "127.0.0.1", DstPort: 81})
 	manager.add(ft.Listener{Exp: "sucka", VM: "vm", DstHost: "127.0.0.1", DstPort: 82})
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		snapshot := manager.snapshot()
 
 		for index, listener := range snapshot {

--- a/src/go/tunneler/manager_test.go
+++ b/src/go/tunneler/manager_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	ft "phenix/web/forward/forwardtypes"
+)
+
+func TestListenerManagerSnapshotIsIndependent(t *testing.T) {
+	var (
+		manager     = newListenerManager()
+		listener, _ = manager.add(ft.Listener{Exp: "experiment", VM: "vm", DstHost: "127.0.0.1", DstPort: 80})
+	)
+
+	err := manager.withListener(listener.ID, func(local *LocalListener) error {
+		local.Listening = true
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("updating listener: %v", err)
+	}
+
+	snapshot := manager.snapshot()
+	if len(snapshot) != 1 {
+		t.Fatalf("snapshot length = %d, want 1", len(snapshot))
+	}
+
+	snapshot[0].Listening = false
+
+	snapshot = manager.snapshot()
+	if !snapshot[0].Listening {
+		t.Fatal("mutating snapshot changed manager state")
+	}
+}
+
+func TestListenerManagerConcurrentAccess(t *testing.T) {
+	var (
+		manager = newListenerManager()
+		wg      sync.WaitGroup
+	)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			listener, _ := manager.add(ft.Listener{
+				Exp:     fmt.Sprintf("experiment-%d", i),
+				VM:      "vm",
+				DstHost: "127.0.0.1",
+				DstPort: 80 + i,
+			})
+
+			err := manager.withListener(listener.ID, func(local *LocalListener) error {
+				local.Listening = true
+				return nil
+			})
+
+			if err != nil {
+				t.Errorf("updating listener: %v", err)
+			}
+
+			manager.snapshot()
+		}(i)
+	}
+
+	wg.Wait()
+
+	if got := len(manager.snapshot()); got != 100 {
+		t.Errorf("snapshot length = %d, want 100", got)
+	}
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			manager.remove(fmt.Sprintf("experiment-%d:vm:127.0.0.1:%d:", i, 80+i))
+		}(i)
+	}
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+
+		go func(int) {
+			defer wg.Done()
+
+			manager.snapshot()
+		}(i)
+	}
+
+	wg.Wait()
+
+	if got := len(manager.snapshot()); got != 0 {
+		t.Errorf("snapshot length after removal = %d, want 0", got)
+	}
+}
+
+func TestListenerManagerIDsAreUniqueAndNotReused(t *testing.T) {
+	var (
+		manager = newListenerManager()
+
+		first, _  = manager.add(ft.Listener{Exp: "experiment-1", VM: "vm", DstHost: "127.0.0.1", DstPort: 80})
+		second, _ = manager.add(ft.Listener{Exp: "experiment-2", VM: "vm", DstHost: "127.0.0.1", DstPort: 81})
+		third, _  = manager.add(ft.Listener{Exp: "experiment-3", VM: "vm", DstHost: "127.0.0.1", DstPort: 82})
+	)
+
+	if first.ID == second.ID {
+		t.Fatalf("listeners received duplicate ID %d", first.ID)
+	}
+
+	manager.remove(first.ToKey())
+
+	if third.ID <= second.ID {
+		t.Fatalf("new listener ID = %d, want greater than %d", third.ID, second.ID)
+	}
+
+	if err := manager.withListener(first.ID, func(*LocalListener) error { return nil }); !errors.Is(err, errListenerNotFound) {
+		t.Fatalf("lookup of removed ID returned %v, want listener-not-found error", err)
+	}
+}
+
+func TestListenerManagerSnapshotIsSorted(t *testing.T) {
+	manager := newListenerManager()
+
+	manager.add(ft.Listener{Exp: "foo", VM: "vm", DstHost: "127.0.0.1", DstPort: 83})
+	manager.add(ft.Listener{Exp: "bar", VM: "vm", DstHost: "127.0.0.1", DstPort: 81})
+	manager.add(ft.Listener{Exp: "sucka", VM: "vm", DstHost: "127.0.0.1", DstPort: 82})
+
+	for i := 0; i < 10; i++ {
+		snapshot := manager.snapshot()
+
+		for index, listener := range snapshot {
+			wantID := index + 1
+
+			if listener.ID != wantID {
+				t.Fatalf("snapshot[%d].ID = %d, want %d", index, listener.ID, wantID)
+			}
+		}
+	}
+}
+
+func TestListenerManagerDuplicateKeyIsIdempotent(t *testing.T) {
+	var (
+		manager  = newListenerManager()
+		listener = ft.Listener{Exp: "experiment", VM: "vm", DstHost: "127.0.0.1", DstPort: 80}
+
+		first, firstCreated   = manager.add(listener)
+		second, secondCreated = manager.add(listener)
+	)
+
+	if !firstCreated || secondCreated {
+		t.Fatalf("duplicate creation flags = (%t, %t), want (true, false)", firstCreated, secondCreated)
+	}
+
+	if first != second {
+		t.Fatal("duplicate creation returned a different listener")
+	}
+
+	err := manager.withListener(first.ID, func(got *LocalListener) error {
+		if got != second {
+			t.Error("lookup returned the wrong listener after duplicate creation")
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("lookup of original listener after duplicate creation: %v", err)
+	}
+
+	if got := len(manager.snapshot()); got != 1 {
+		t.Fatalf("snapshot length = %d, want 1", got)
+	}
+}

--- a/src/go/tunneler/move_test.go
+++ b/src/go/tunneler/move_test.go
@@ -60,7 +60,7 @@ func TestMoveLocalListenerRollsBackOnBindFailure(t *testing.T) {
 
 func TestMoveLocalListenerInactiveListener(t *testing.T) {
 	var (
-		listener = &LocalListener{Listener: ft.Listener{SrcPort: freeTCPPort(t)}} //nolint:exhaustruct // partial initialization
+		listener = &LocalListener{Listener: ft.Listener{SrcPort: freeTCPPort(t)}}
 		newPort  = freeTCPPort(t)
 	)
 
@@ -80,7 +80,7 @@ func TestMoveLocalListenerInactiveListener(t *testing.T) {
 func newTestLocalListener(t *testing.T) *LocalListener {
 	t.Helper()
 
-	listener := &LocalListener{Listener: ft.Listener{SrcPort: freeTCPPort(t)}} //nolint:exhaustruct // partial initialization
+	listener := &LocalListener{Listener: ft.Listener{SrcPort: freeTCPPort(t)}}
 
 	if err := activateLocalListener(listener); err != nil {
 		t.Fatalf("activating test listener: %v", err)

--- a/src/go/tunneler/move_test.go
+++ b/src/go/tunneler/move_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	ft "phenix/web/forward/forwardtypes"
+)
+
+func TestMoveLocalListenerActiveListener(t *testing.T) {
+	var (
+		listener = newTestLocalListener(t)
+		newPort  = freeTCPPort(t)
+	)
+
+	if err := moveLocalListener(listener, newPort); err != nil {
+		t.Fatalf("moving listener: %v", err)
+	}
+
+	if listener.SrcPort != newPort {
+		t.Fatalf("listener port = %d, want %d", listener.SrcPort, newPort)
+	}
+
+	if !listener.Listening {
+		t.Fatal("listener is inactive after successful move")
+	}
+
+	deactivateTestListener(t, listener)
+}
+
+func TestMoveLocalListenerRollsBackOnBindFailure(t *testing.T) {
+	var (
+		listener = newTestLocalListener(t)
+		oldPort  = listener.SrcPort
+	)
+
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("creating occupied listener: %v", err)
+	}
+
+	defer func() { _ = occupied.Close() }()
+
+	targetPort := occupied.Addr().(*net.TCPAddr).Port
+
+	if err := moveLocalListener(listener, targetPort); err == nil {
+		t.Fatal("moving listener to occupied port returned nil error")
+	}
+
+	if listener.SrcPort != oldPort {
+		t.Fatalf("listener port after rollback = %d, want %d", listener.SrcPort, oldPort)
+	}
+
+	if !listener.Listening {
+		t.Fatal("listener is inactive after rollback")
+	}
+
+	deactivateTestListener(t, listener)
+}
+
+func TestMoveLocalListenerInactiveListener(t *testing.T) {
+	var (
+		listener = &LocalListener{Listener: ft.Listener{SrcPort: freeTCPPort(t)}} //nolint:exhaustruct // partial initialization
+		newPort  = freeTCPPort(t)
+	)
+
+	if err := moveLocalListener(listener, newPort); err != nil {
+		t.Fatalf("moving inactive listener: %v", err)
+	}
+
+	if listener.SrcPort != newPort {
+		t.Fatalf("listener port = %d, want %d", listener.SrcPort, newPort)
+	}
+
+	if listener.Listening {
+		t.Fatal("inactive listener became active after move")
+	}
+}
+
+func newTestLocalListener(t *testing.T) *LocalListener {
+	t.Helper()
+
+	listener := &LocalListener{Listener: ft.Listener{SrcPort: freeTCPPort(t)}} //nolint:exhaustruct // partial initialization
+
+	if err := activateLocalListener(listener); err != nil {
+		t.Fatalf("activating test listener: %v", err)
+	}
+
+	return listener
+}
+
+func deactivateTestListener(t *testing.T, listener *LocalListener) {
+	t.Helper()
+
+	if err := deactivateLocalListener(listener); err != nil {
+		t.Fatalf("deactivating test listener: %v", err)
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("getting free TCP port: %v", err)
+	}
+
+	defer func() { _ = listener.Close() }()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}

--- a/src/go/tunneler/server.go
+++ b/src/go/tunneler/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -58,8 +57,8 @@ func handleConnection(conn net.Conn) {
 	defer func() { _ = conn.Close() }()
 
 	var (
-		enc = gob.NewEncoder(conn)
-		dec = gob.NewDecoder(conn)
+		enc = json.NewEncoder(conn)
+		dec = json.NewDecoder(conn)
 	)
 
 	var msg Message
@@ -73,18 +72,21 @@ func handleConnection(conn net.Conn) {
 
 	switch msg.Type {
 	case LISTENERS:
-		msg.Payload = localListeners.snapshot()
+		msg.Payload = marshalPayload(localListeners.snapshot())
 
 		err := enc.Encode(msg)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: encoding %v message: %v\n", msg.Type, err)
 		}
 	case MOVE:
-		args, ok := msg.Payload.([]int)
-		if ok && len(args) == 2 {
+		var args listenerAction
+
+		if err := json.Unmarshal(msg.Payload, &args); err != nil {
+			msg.Error = "malformed move arguments provided"
+		} else {
 			var (
-				id   = args[0]
-				port = args[1]
+				id   = args.ID
+				port = args.Port
 			)
 
 			if err := validateListenerID(id); err != nil {
@@ -104,9 +106,11 @@ func handleConnection(conn net.Conn) {
 				if errors.Is(err, errListenerNotFound) {
 					msg.Error = fmt.Sprintf("listener %d not found", id)
 				}
+
+				if err == nil {
+					broadcastWebListeners()
+				}
 			}
-		} else {
-			msg.Error = "malformed move arguments provided"
 		}
 
 		err := enc.Encode(msg)
@@ -114,8 +118,11 @@ func handleConnection(conn net.Conn) {
 			fmt.Fprintf(os.Stderr, "ERROR: encoding %v message: %v\n", msg.Type, err)
 		}
 	case ACTIVATE:
-		id, ok := msg.Payload.(int)
-		if ok {
+		var args listenerAction
+		if err := json.Unmarshal(msg.Payload, &args); err != nil {
+			msg.Error = "malformed listener ID provided"
+		} else {
+			id := args.ID
 			if err := validateListenerID(id); err != nil {
 				msg.Error = err.Error()
 			} else {
@@ -136,9 +143,11 @@ func handleConnection(conn net.Conn) {
 				if errors.Is(err, errListenerNotFound) {
 					msg.Error = fmt.Sprintf("listener %d not found", id)
 				}
+
+				if err == nil {
+					broadcastWebListeners()
+				}
 			}
-		} else {
-			msg.Error = "malformed listener ID provided"
 		}
 
 		err := enc.Encode(msg)
@@ -146,8 +155,11 @@ func handleConnection(conn net.Conn) {
 			fmt.Fprintf(os.Stderr, "ERROR: encoding %v message: %v\n", msg.Type, err)
 		}
 	case DEACTIVATE:
-		id, ok := msg.Payload.(int)
-		if ok {
+		var args listenerAction
+		if err := json.Unmarshal(msg.Payload, &args); err != nil {
+			msg.Error = "malformed listener ID provided"
+		} else {
+			id := args.ID
 			if err := validateListenerID(id); err != nil {
 				msg.Error = err.Error()
 			} else {
@@ -168,9 +180,11 @@ func handleConnection(conn net.Conn) {
 				if errors.Is(err, errListenerNotFound) {
 					msg.Error = fmt.Sprintf("listener %d not found", id)
 				}
+
+				if err == nil {
+					broadcastWebListeners()
+				}
 			}
-		} else {
-			msg.Error = "malformed listener ID provided"
 		}
 
 		err := enc.Encode(msg)
@@ -347,8 +361,13 @@ func createLocalListener(listener ft.Listener) error {
 	fmt.Fprintf(os.Stdout, "created new local listener for port %d\n", listener.SrcPort)
 
 	if username == "" || username == listener.Owner {
-		return localListeners.withListener(local.ID, activateLocalListener)
+		err := localListeners.withListener(local.ID, activateLocalListener)
+
+		broadcastWebListeners()
+		return err
 	}
+
+	broadcastWebListeners()
 
 	return nil
 }
@@ -474,6 +493,7 @@ func deactivateLocalListener(ll *LocalListener) error {
 func deleteLocalListener(key string) {
 	port, ok := localListeners.remove(key)
 	if ok {
+		broadcastWebListeners()
 		fmt.Fprintf(os.Stdout, "deleted local listener on port %d\n", port)
 	}
 }

--- a/src/go/tunneler/server.go
+++ b/src/go/tunneler/server.go
@@ -73,13 +73,7 @@ func handleConnection(conn net.Conn) {
 
 	switch msg.Type {
 	case LISTENERS:
-		var payload Listeners
-
-		for _, l := range listeners {
-			payload = append(payload, *l)
-		}
-
-		msg.Payload = payload
+		msg.Payload = localListeners.snapshot()
 
 		err := enc.Encode(msg)
 		if err != nil {
@@ -87,24 +81,32 @@ func handleConnection(conn net.Conn) {
 		}
 	case MOVE:
 		args, ok := msg.Payload.([]int)
-		if ok {
+		if ok && len(args) == 2 {
 			var (
 				id   = args[0]
 				port = args[1]
 			)
 
-			for _, listener := range listeners {
-				if listener.ID == id {
+			if err := validateListenerID(id); err != nil {
+				msg.Error = err.Error()
+			} else if err := validateLocalPort(port); err != nil {
+				msg.Error = err.Error()
+			} else {
+				err := localListeners.withListener(id, func(listener *LocalListener) error {
 					err := moveLocalListener(listener, port)
 					if err != nil {
 						msg.Error = fmt.Sprintf("moving listener %d to port %d: %v", id, port, err)
 					}
 
-					break
+					return err
+				})
+
+				if errors.Is(err, errListenerNotFound) {
+					msg.Error = fmt.Sprintf("listener %d not found", id)
 				}
 			}
 		} else {
-			msg.Error = "malformed arguments provided"
+			msg.Error = "malformed move arguments provided"
 		}
 
 		err := enc.Encode(msg)
@@ -114,18 +116,25 @@ func handleConnection(conn net.Conn) {
 	case ACTIVATE:
 		id, ok := msg.Payload.(int)
 		if ok {
-			for _, listener := range listeners {
-				if listener.ID == id {
+			if err := validateListenerID(id); err != nil {
+				msg.Error = err.Error()
+			} else {
+				err := localListeners.withListener(id, func(listener *LocalListener) error {
 					if listener.Listening {
 						msg.Error = fmt.Sprintf("listener %d is already active", id)
-					} else {
-						err := activateLocalListener(listener)
-						if err != nil {
-							msg.Error = fmt.Sprintf("activating listener %d: %v", id, err)
-						}
+						return nil
 					}
 
-					break
+					err := activateLocalListener(listener)
+					if err != nil {
+						msg.Error = fmt.Sprintf("activating listener %d: %v", id, err)
+					}
+
+					return err
+				})
+
+				if errors.Is(err, errListenerNotFound) {
+					msg.Error = fmt.Sprintf("listener %d not found", id)
 				}
 			}
 		} else {
@@ -139,18 +148,25 @@ func handleConnection(conn net.Conn) {
 	case DEACTIVATE:
 		id, ok := msg.Payload.(int)
 		if ok {
-			for _, listener := range listeners {
-				if listener.ID == id {
+			if err := validateListenerID(id); err != nil {
+				msg.Error = err.Error()
+			} else {
+				err := localListeners.withListener(id, func(listener *LocalListener) error {
 					if !listener.Listening {
 						msg.Error = fmt.Sprintf("listener %d is already inactive", id)
-					} else {
-						err := deactivateLocalListener(listener)
-						if err != nil {
-							msg.Error = fmt.Sprintf("deactivating listener %d: %v", id, err)
-						}
+						return nil
 					}
 
-					break
+					err := deactivateLocalListener(listener)
+					if err != nil {
+						msg.Error = fmt.Sprintf("deactivating listener %d: %v", id, err)
+					}
+
+					return err
+				})
+
+				if errors.Is(err, errListenerNotFound) {
+					msg.Error = fmt.Sprintf("listener %d not found", id)
 				}
 			}
 		} else {
@@ -323,20 +339,25 @@ func getRemoteVMs(client *http.Client, url string) ([]string, error) {
 }
 
 func createLocalListener(listener ft.Listener) error {
-	local := &LocalListener{ID: <-listenerIDs, Listener: listener} //nolint:exhaustruct // partial initialization
-	listeners[listener.ToKey()] = local
+	local, created := localListeners.add(listener)
+	if !created {
+		return nil
+	}
 
 	fmt.Fprintf(os.Stdout, "created new local listener for port %d\n", listener.SrcPort)
 
 	if username == "" || username == listener.Owner {
-		return activateLocalListener(local)
+		return localListeners.withListener(local.ID, activateLocalListener)
 	}
 
 	return nil
 }
 
 func moveLocalListener(ll *LocalListener, port int) error {
-	active := ll.Listening
+	var (
+		active  = ll.Listening
+		oldPort = ll.SrcPort
+	)
 
 	if active {
 		err := deactivateLocalListener(ll)
@@ -348,9 +369,19 @@ func moveLocalListener(ll *LocalListener, port int) error {
 	ll.SrcPort = port
 
 	if active {
-		err := activateLocalListener(ll)
-		if err != nil {
-			return fmt.Errorf("reactivating listener: %w", err)
+		if err := activateLocalListener(ll); err != nil {
+			moveErr := fmt.Errorf("reactivating listener on port %d: %w", port, err)
+
+			ll.SrcPort = oldPort
+
+			if restoreErr := activateLocalListener(ll); restoreErr != nil {
+				return errors.Join(
+					moveErr,
+					fmt.Errorf("restoring listener on port %d: %w", oldPort, restoreErr),
+				)
+			}
+
+			return moveErr
 		}
 	}
 
@@ -362,6 +393,8 @@ func activateLocalListener(ll *LocalListener) error {
 		return errors.New("listener already active")
 	}
 
+	localPort := ll.SrcPort
+
 	//nolint:exhaustruct // partial initialization
 	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf(":%d", ll.SrcPort))
 	if err != nil {
@@ -371,16 +404,16 @@ func activateLocalListener(ll *LocalListener) error {
 				ll.SrcPort,
 			)
 
-			return nil
+			return fmt.Errorf("unable to activate local listener on port %d: address already in use", localPort)
 		}
 
-		return fmt.Errorf("listening on port %d: %w", ll.SrcPort, err)
+		return fmt.Errorf("listening on port %d: %w", localPort, err)
 	}
 
 	ll.listener = ln
 	ll.Listening = true
 
-	fmt.Fprintf(os.Stdout, "activated local listener on port %d\n", ll.SrcPort)
+	fmt.Fprintf(os.Stdout, "activated local listener on port %d\n", localPort)
 
 	go func() {
 		for {
@@ -388,7 +421,7 @@ func activateLocalListener(ll *LocalListener) error {
 			if err != nil {
 				// this error is expected when connection is closed
 				if !strings.Contains(err.Error(), "use of closed network connection") {
-					fmt.Fprintf(os.Stderr, "accepting new connection on port %d: %v\n", ll.SrcPort, err)
+					fmt.Fprintf(os.Stderr, "accepting new connection on port %d: %v\n", localPort, err)
 				}
 
 				return
@@ -439,14 +472,8 @@ func deactivateLocalListener(ll *LocalListener) error {
 }
 
 func deleteLocalListener(key string) {
-	ll, ok := listeners[key]
-
-	// listener may be nil if deactivated when getting deleted
-	if ok && ll.listener != nil {
-		_ = ll.listener.Close()
+	port, ok := localListeners.remove(key)
+	if ok {
+		fmt.Fprintf(os.Stdout, "deleted local listener on port %d\n", port)
 	}
-
-	delete(listeners, key)
-
-	fmt.Fprintf(os.Stdout, "deleted local listener on port %d\n", ll.SrcPort)
 }

--- a/src/go/tunneler/server_test.go
+++ b/src/go/tunneler/server_test.go
@@ -1,12 +1,39 @@
 package main
 
 import (
-	"encoding/gob"
+	"encoding/json"
 	"net"
 	"testing"
 
 	ft "phenix/web/forward/forwardtypes"
 )
+
+func TestLocalListenerJSONUsesStableFieldNames(t *testing.T) {
+	data, err := json.Marshal(LocalListener{
+		ID:        7,
+		Listening: true,
+	})
+	if err != nil {
+		t.Fatalf("marshaling local listener: %v", err)
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decoding local listener JSON: %v", err)
+	}
+
+	for _, field := range []string{"id", "listening"} {
+		if _, ok := payload[field]; !ok {
+			t.Errorf("listener JSON missing %q: %s", field, data)
+		}
+	}
+
+	for _, field := range []string{"ID", "Listening"} {
+		if _, ok := payload[field]; ok {
+			t.Errorf("listener JSON unexpectedly contains %q: %s", field, data)
+		}
+	}
+}
 
 func TestListenerOperationsReportUnknownIDs(t *testing.T) {
 	previousManager := localListeners
@@ -20,15 +47,15 @@ func TestListenerOperationsReportUnknownIDs(t *testing.T) {
 	}{
 		{
 			name:    "move",
-			message: Message{Type: MOVE, Payload: []int{1, 12345}},
+			message: Message{Type: MOVE, Payload: json.RawMessage(`{"id":1,"port":12345}`)},
 		},
 		{
 			name:    "activate",
-			message: Message{Type: ACTIVATE, Payload: 1},
+			message: Message{Type: ACTIVATE, Payload: json.RawMessage(`{"id":1}`)},
 		},
 		{
 			name:    "deactivate",
-			message: Message{Type: DEACTIVATE, Payload: 1},
+			message: Message{Type: DEACTIVATE, Payload: json.RawMessage(`{"id":1}`)},
 		},
 	}
 
@@ -52,7 +79,7 @@ func TestActivateLocalListenerReportsOccupiedPort(t *testing.T) {
 
 	var (
 		port     = occupied.Addr().(*net.TCPAddr).Port
-		listener = &LocalListener{Listener: ft.Listener{SrcPort: port}} //nolint:exhaustruct // partial initialization
+		listener = &LocalListener{Listener: ft.Listener{SrcPort: port}}
 	)
 
 	if err := activateLocalListener(listener); err == nil {
@@ -69,11 +96,11 @@ func TestListenerOperationsRejectMalformedPayloads(t *testing.T) {
 		name    string
 		message Message
 	}{
-		{name: "empty move payload", message: Message{Type: MOVE, Payload: []int{}}},
-		{name: "short move payload", message: Message{Type: MOVE, Payload: []int{1}}},
-		{name: "wrong move payload", message: Message{Type: MOVE, Payload: "1,12345"}},
-		{name: "wrong activate payload", message: Message{Type: ACTIVATE, Payload: "1"}},
-		{name: "wrong deactivate payload", message: Message{Type: DEACTIVATE, Payload: "1"}},
+		{name: "empty move payload", message: Message{Type: MOVE, Payload: json.RawMessage(`[]`)}},
+		{name: "short move payload", message: Message{Type: MOVE, Payload: json.RawMessage(`[1]`)}},
+		{name: "wrong move payload", message: Message{Type: MOVE, Payload: json.RawMessage(`"1,12345"`)}},
+		{name: "wrong activate payload", message: Message{Type: ACTIVATE, Payload: json.RawMessage(`"1"`)}},
+		{name: "wrong deactivate payload", message: Message{Type: DEACTIVATE, Payload: json.RawMessage(`"1"`)}},
 	}
 
 	for _, test := range tests {
@@ -99,12 +126,12 @@ func sendListenerMessage(t *testing.T, message Message) Message {
 		close(done)
 	}()
 
-	if err := gob.NewEncoder(client).Encode(message); err != nil {
+	if err := json.NewEncoder(client).Encode(message); err != nil {
 		t.Fatalf("sending message: %v", err)
 	}
 
 	var response Message
-	if err := gob.NewDecoder(client).Decode(&response); err != nil {
+	if err := json.NewDecoder(client).Decode(&response); err != nil {
 		t.Fatalf("receiving response: %v", err)
 	}
 

--- a/src/go/tunneler/server_test.go
+++ b/src/go/tunneler/server_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/gob"
+	"net"
+	"testing"
+
+	ft "phenix/web/forward/forwardtypes"
+)
+
+func TestListenerOperationsReportUnknownIDs(t *testing.T) {
+	previousManager := localListeners
+	localListeners = newListenerManager()
+
+	defer func() { localListeners = previousManager }()
+
+	tests := []struct {
+		name    string
+		message Message
+	}{
+		{
+			name:    "move",
+			message: Message{Type: MOVE, Payload: []int{1, 12345}},
+		},
+		{
+			name:    "activate",
+			message: Message{Type: ACTIVATE, Payload: 1},
+		},
+		{
+			name:    "deactivate",
+			message: Message{Type: DEACTIVATE, Payload: 1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := sendListenerMessage(t, test.message)
+			if response.Error != "listener 1 not found" {
+				t.Fatalf("response error = %q, want listener-not-found error", response.Error)
+			}
+		})
+	}
+}
+
+func TestActivateLocalListenerReportsOccupiedPort(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("creating occupied listener: %v", err)
+	}
+
+	defer func() { _ = occupied.Close() }()
+
+	var (
+		port     = occupied.Addr().(*net.TCPAddr).Port
+		listener = &LocalListener{Listener: ft.Listener{SrcPort: port}} //nolint:exhaustruct // partial initialization
+	)
+
+	if err := activateLocalListener(listener); err == nil {
+		t.Fatal("activating on an occupied port returned nil error")
+	}
+
+	if listener.Listening {
+		t.Fatal("listener marked active after bind failure")
+	}
+}
+
+func TestListenerOperationsRejectMalformedPayloads(t *testing.T) {
+	tests := []struct {
+		name    string
+		message Message
+	}{
+		{name: "empty move payload", message: Message{Type: MOVE, Payload: []int{}}},
+		{name: "short move payload", message: Message{Type: MOVE, Payload: []int{1}}},
+		{name: "wrong move payload", message: Message{Type: MOVE, Payload: "1,12345"}},
+		{name: "wrong activate payload", message: Message{Type: ACTIVATE, Payload: "1"}},
+		{name: "wrong deactivate payload", message: Message{Type: DEACTIVATE, Payload: "1"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := sendListenerMessage(t, test.message)
+			if response.Error == "" {
+				t.Fatal("malformed payload returned no error")
+			}
+		})
+	}
+}
+
+func sendListenerMessage(t *testing.T, message Message) Message {
+	t.Helper()
+
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	done := make(chan struct{})
+
+	go func() {
+		handleConnection(server)
+		close(done)
+	}()
+
+	if err := gob.NewEncoder(client).Encode(message); err != nil {
+		t.Fatalf("sending message: %v", err)
+	}
+
+	var response Message
+	if err := gob.NewDecoder(client).Decode(&response); err != nil {
+		t.Fatalf("receiving response: %v", err)
+	}
+
+	<-done
+
+	return response
+}

--- a/src/go/tunneler/types.go
+++ b/src/go/tunneler/types.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"encoding/gob"
+	"encoding/json"
 	"net"
 	"net/http"
 
@@ -38,21 +38,22 @@ const (
 type LocalListener struct {
 	ft.Listener
 
-	ID int
+	ID int `json:"id"`
 
-	Listening bool
+	Listening bool `json:"listening"`
 	listener  net.Listener
 }
 
 type Message struct {
-	MID     int
-	Type    MessageType
-	Payload any
-	Error   string
+	MID     int             `json:"mid"`
+	Type    MessageType     `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+	Error   string          `json:"error,omitempty"`
 }
 
 type Listeners []LocalListener
 
-func init() { //nolint:gochecknoinits // gob registration
-	gob.Register(Listeners{})
+type listenerAction struct {
+	ID   int `json:"id"`
+	Port int `json:"port,omitempty"`
 }

--- a/src/go/tunneler/validation.go
+++ b/src/go/tunneler/validation.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func parseListenerID(value string) (int, error) {
+	id, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("malformed listener ID provided (%s): %w", value, err)
+	}
+
+	if err := validateListenerID(id); err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+func parseLocalPort(value string) (int, error) {
+	port, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("malformed listener port provided (%s): %w", value, err)
+	}
+
+	if err := validateLocalPort(port); err != nil {
+		return 0, err
+	}
+
+	return port, nil
+}
+
+func validateListenerID(id int) error {
+	if id <= 0 {
+		return fmt.Errorf("listener ID must be positive: %d", id)
+	}
+
+	return nil
+}
+
+func validateLocalPort(port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("listener port must be between 1 and 65535: %d", port)
+	}
+
+	return nil
+}

--- a/src/go/tunneler/validation_test.go
+++ b/src/go/tunneler/validation_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestTunnelerCommandArgumentCounts(t *testing.T) {
+	tests := []struct {
+		name    string
+		command cobra.PositionalArgs
+		args    []string
+	}{
+		{name: "list missing", command: listCmd.Args, args: []string{"unexpected"}},
+		{name: "activate missing", command: activateCmd.Args, args: nil},
+		{name: "activate extra", command: activateCmd.Args, args: []string{"1", "2"}},
+		{name: "deactivate missing", command: deactivateCmd.Args, args: nil},
+		{name: "deactivate extra", command: deactivateCmd.Args, args: []string{"1", "2"}},
+		{name: "move missing", command: moveCmd.Args, args: []string{"1"}},
+		{name: "move extra", command: moveCmd.Args, args: []string{"1", "2", "3"}},
+		{name: "serve missing", command: serveCmd.Args, args: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.command(&cobra.Command{Use: test.name}, test.args); err == nil {
+				t.Fatal("expected argument validation error")
+			}
+		})
+	}
+}
+
+func TestListenerIDValidation(t *testing.T) {
+	for _, value := range []string{"", "abc", "0", "-1"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseListenerID(value); err == nil {
+				t.Fatalf("parseListenerID(%q) returned nil error", value)
+			}
+		})
+	}
+}
+
+func TestLocalPortValidation(t *testing.T) {
+	for _, value := range []string{"", "abc", "0", "-1", "65536"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseLocalPort(value); err == nil {
+				t.Fatalf("parseLocalPort(%q) returned nil error", value)
+			}
+		})
+	}
+
+	for _, value := range []string{"1", "65535"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseLocalPort(value); err != nil {
+				t.Fatalf("parseLocalPort(%q) returned error: %v", value, err)
+			}
+		})
+	}
+}

--- a/src/go/tunneler/web.go
+++ b/src/go/tunneler/web.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"errors"
+	"html/template"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/websocket"
+)
+
+//go:embed web/index.html
+var webTemplateFS embed.FS
+
+type webPageData struct {
+	Listeners Listeners
+	Origin    string
+	Message   string
+	Error     string
+}
+
+type webEventHub struct {
+	mu       sync.Mutex
+	clients  map[*webEventClient]struct{}
+	template *template.Template
+}
+
+type webEventClient struct {
+	conn     *websocket.Conn
+	messages chan string
+}
+
+var webEvents = &webEventHub{clients: make(map[*webEventClient]struct{})} //nolint:gochecknoglobals,exhaustruct // local web server state
+
+func (h *webEventHub) setTemplate(tmpl *template.Template) {
+	h.mu.Lock()
+	h.template = tmpl
+	h.mu.Unlock()
+}
+
+func (h *webEventHub) add(conn *websocket.Conn) *webEventClient {
+	client := &webEventClient{conn: conn, messages: make(chan string, 1)}
+
+	h.mu.Lock()
+	h.clients[client] = struct{}{}
+	h.mu.Unlock()
+
+	client.sendListeners(localListeners.snapshot())
+
+	return client
+}
+
+func (h *webEventHub) remove(client *webEventClient) {
+	h.mu.Lock()
+	delete(h.clients, client)
+	h.mu.Unlock()
+}
+
+func (h *webEventHub) broadcast(listeners Listeners) {
+	h.mu.Lock()
+
+	var (
+		tmpl    = h.template
+		clients = make([]*webEventClient, 0, len(h.clients))
+	)
+
+	for client := range h.clients {
+		clients = append(clients, client)
+	}
+
+	h.mu.Unlock()
+
+	if tmpl == nil {
+		return
+	}
+
+	payload, err := renderWebListeners(tmpl, listeners)
+	if err != nil {
+		return
+	}
+
+	for _, client := range clients {
+		client.send(string(payload))
+	}
+}
+
+func (c *webEventClient) sendListeners(listeners Listeners) {
+	webEvents.mu.Lock()
+	tmpl := webEvents.template
+	webEvents.mu.Unlock()
+
+	if tmpl == nil {
+		return
+	}
+
+	payload, err := renderWebListeners(tmpl, listeners)
+	if err == nil {
+		c.send(string(payload))
+	}
+}
+
+func (c *webEventClient) send(payload string) {
+	select {
+	case c.messages <- payload:
+	default:
+		<-c.messages
+		c.messages <- payload
+	}
+}
+
+func broadcastWebListeners() {
+	webEvents.broadcast(localListeners.snapshot())
+}
+
+func startWebServer(addr string) error {
+	handler, err := newWebHandler()
+	if err != nil {
+		return err
+	}
+
+	listener, err := new(net.ListenConfig).Listen( //nolint:gosec // address is configured by the local user
+		context.Background(), "tcp", addr,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	server := &http.Server{Handler: handler}
+	go server.Serve(listener) //nolint:errcheck // Goroutine
+
+	return nil
+}
+
+func newWebHandler() (http.Handler, error) {
+	tmpl, err := template.ParseFS(webTemplateFS, "web/index.html")
+	if err != nil {
+		return nil, err
+	}
+
+	webEvents.setTemplate(tmpl)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		renderWebPage(w, tmpl, webPageData{ //nolint:exhaustruct // partial initialization
+			Listeners: localListeners.snapshot(),
+			Origin:    origin,
+		})
+	})
+
+	mux.HandleFunc("/listeners/", func(w http.ResponseWriter, r *http.Request) {
+		handleWebListenerAction(w, r, tmpl)
+	})
+
+	mux.Handle("/events", websocket.Handler(func(conn *websocket.Conn) {
+		client := webEvents.add(conn)
+		defer webEvents.remove(client)
+
+		for payload := range client.messages {
+			if err := websocket.Message.Send(conn, payload); err != nil {
+				return
+			}
+		}
+	}))
+
+	return mux, nil
+}
+
+func handleWebListenerAction(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+
+	if len(parts) != 3 { //nolint:mnd // path is in the form of '/listeners/{{id}}/{{action}}'
+		http.NotFound(w, r)
+		return
+	}
+
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		renderWebError(w, tmpl, http.StatusBadRequest, "malformed listener ID")
+		return
+	}
+
+	if err := validateListenerID(id); err != nil {
+		renderWebError(w, tmpl, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var action func(*LocalListener) error
+	switch parts[2] {
+	case "activate":
+		action = activateLocalListener
+	case "deactivate":
+		action = deactivateLocalListener
+	case "move":
+		if err := r.ParseForm(); err != nil {
+			renderWebError(w, tmpl, http.StatusBadRequest, "parsing form: "+err.Error())
+			return
+		}
+
+		port, err := parseLocalPort(r.FormValue("port"))
+		if err != nil {
+			renderWebError(w, tmpl, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		action = func(listener *LocalListener) error {
+			return moveLocalListener(listener, port)
+		}
+	default:
+		http.NotFound(w, r)
+		return
+	}
+
+	err = localListeners.withListener(id, action)
+	if errors.Is(err, errListenerNotFound) {
+		renderWebError(w, tmpl, http.StatusNotFound, "listener "+strconv.Itoa(id)+" not found")
+		return
+	}
+
+	if err != nil {
+		renderWebError(w, tmpl, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	broadcastWebListeners()
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func renderWebPage(w http.ResponseWriter, tmpl *template.Template, data webPageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.Execute(w, data); err != nil {
+		http.Error(w, "unable to render page", http.StatusInternalServerError)
+	}
+}
+
+func renderWebListeners(tmpl *template.Template, listeners Listeners) ([]byte, error) {
+	var body bytes.Buffer
+
+	if err := tmpl.ExecuteTemplate(&body, "listenerRows", listeners); err != nil {
+		return nil, err
+	}
+
+	return body.Bytes(), nil
+}
+
+func renderWebError(w http.ResponseWriter, tmpl *template.Template, status int, message string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+
+	renderWebPage(w, tmpl, webPageData{ //nolint:exhaustruct // partial initialization
+		Listeners: localListeners.snapshot(),
+		Origin:    origin,
+		Error:     message,
+	})
+}

--- a/src/go/tunneler/web/index.html
+++ b/src/go/tunneler/web/index.html
@@ -1,0 +1,105 @@
+{{define "listenerRows"}}
+{{if .}}
+{{range .}}
+<tr>
+  <td data-label="ID">{{.ID}}</td>
+  <td data-label="Experiment">{{.Exp}}</td>
+  <td data-label="VM">{{.VM}}</td>
+  <td data-label="Remote">{{.DstHost}}:{{.DstPort}}</td>
+  <td data-label="Local">localhost:{{.SrcPort}}</td>
+  <td data-label="State" class="{{if .Listening}}active{{else}}inactive{{end}}">{{if .Listening}}Active{{else}}Inactive{{end}}</td>
+  <td data-label="EnableDisable">
+    {{if .Listening}}
+    <form method="post" action="/listeners/{{.ID}}/deactivate"><button type="submit">Disable</button></form>
+    {{else}}
+    <form method="post" action="/listeners/{{.ID}}/activate"><button type="submit">Enable</button></form>
+    {{end}}
+  </td>
+  <td data-label="Move">
+    <form method="post" action="/listeners/{{.ID}}/move">
+      <input type="number" name="port" min="1" max="65535" value="{{.SrcPort}}" aria-label="New local port">
+      <button type="submit">Move</button>
+    </form>
+  </td>
+</tr>
+{{end}}
+{{else}}<tr><td colspan="7">No listeners are registered.</td></tr>{{end}}
+{{end}}
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>phēnix tunneler</title>
+    <style>
+      :root { color-scheme: dark; font-family: system-ui, sans-serif; }
+      body { background: #15171a; color: #e8eaed; margin: 0; }
+      main { margin: 0 auto; max-width: 1100px; padding: 2rem 1rem; }
+      h1 { font-size: 1.7rem; margin: 0 0 .35rem; }
+      p { color: #aeb4bc; }
+      .notice { background: #253b2c; border: 1px solid #41714d; border-radius: .35rem; padding: .8rem 1rem; }
+      .error { background: #482b2b; border-color: #a85b5b; }
+      table { border-collapse: collapse; margin-top: 1.5rem; width: 100%; }
+      th, td { border-bottom: 1px solid #30343a; padding: .75rem .5rem; text-align: left; vertical-align: middle; }
+      th { color: #aeb4bc; font-size: .8rem; text-transform: uppercase; }
+      .actions { text-align: center; }
+      form { display: inline-flex; gap: .35rem; }
+      button, input { background: #24282e; border: 1px solid #505861; border-radius: .25rem; color: inherit; padding: .4rem .55rem; }
+      button { cursor: pointer; }
+      button:hover { background: #343a42; }
+      input[type=number] { width: 5.5rem; }
+      .active { color: #74d68a; }
+      .inactive { color: #e0a85c; }
+      @media (max-width: 700px) {
+        thead { display: none; }
+        tr, td { display: block; }
+        tr { border-bottom: 1px solid #30343a; padding: .75rem 0; }
+        td { border: 0; padding: .25rem 0; }
+        td::before { color: #aeb4bc; content: attr(data-label) ": "; font-weight: 600; }
+        td.actions::before { display: block; margin-bottom: .3rem; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>phēnix tunneler</h1>
+      <p>Manage local listeners for port forwards created in phēnix (at <strong>{{.Origin}}</strong>).</p>
+      <p id="connection-status">Live updates connecting...</p>
+      {{if .Message}}<div class="notice">{{.Message}}</div>{{end}}
+      {{if .Error}}<div class="notice error">{{.Error}}</div>{{end}}
+      <table>
+        <thead><tr><th>ID</th><th>Experiment</th><th>VM</th><th>Remote</th><th>Local</th><th>State</th><th colspan="2" class="actions">Actions</th></tr></thead>
+        <tbody id="listener-body">
+        {{template "listenerRows" .Listeners}}
+        </tbody>
+      </table>
+    </main>
+    <script>
+      (() => {
+        const body = document.getElementById('listener-body');
+        const status = document.getElementById('connection-status');
+
+        const connect = () => {
+          const url = new URL('/events', window.location.href);
+          url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+
+          const socket = new WebSocket(url);
+
+          socket.onopen = () => { status.textContent = 'Live updates connected'; };
+
+          socket.onmessage = (event) => {
+            body.innerHTML = event.data;
+          };
+
+          socket.onclose = () => {
+            status.textContent = 'Live updates disconnected, retrying...';
+            window.setTimeout(connect, 1000);
+          };
+        };
+
+        connect();
+      })();
+    </script>
+  </body>
+</html>

--- a/src/go/tunneler/web_test.go
+++ b/src/go/tunneler/web_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/websocket"
+
+	ft "phenix/web/forward/forwardtypes"
+)
+
+func TestWebInterfaceListsAndManagesListeners(t *testing.T) {
+	previousManager := localListeners
+	previousOrigin := origin
+	localListeners = newListenerManager()
+	origin = "https://phenix.example.test/base"
+	defer func() { localListeners = previousManager }()
+	defer func() { origin = previousOrigin }()
+
+	listener, created := localListeners.add(ft.Listener{
+		Exp: "experiment", VM: "vm", SrcPort: 12345, DstHost: "127.0.0.1", DstPort: 80,
+	})
+
+	if !created {
+		t.Fatal("listener was not created")
+	}
+
+	handler, err := newWebHandler()
+	if err != nil {
+		t.Fatalf("creating web handler: %v", err)
+	}
+
+	response := serveWebRequest(t, handler, http.MethodGet, "/", "")
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want %d", response.Code, http.StatusOK)
+	}
+
+	for _, want := range []string{
+		"https://phenix.example.test/base",
+		"experiment",
+		"vm",
+		"127.0.0.1:80",
+		"localhost:12345",
+		"Enable",
+	} {
+		if !strings.Contains(response.Body.String(), want) {
+			t.Errorf("GET / does not contain %q", want)
+		}
+	}
+
+	response = serveWebRequest(t, handler, http.MethodPost, "/listeners/1/move", "port=12346")
+
+	if response.Code != http.StatusSeeOther || listener.SrcPort != 12346 {
+		t.Fatalf("move response = (%d, port %d), want (%d, port 12346)", response.Code, listener.SrcPort, http.StatusSeeOther)
+	}
+
+	port := freeTCPPort(t)
+	response = serveWebRequest(t, handler, http.MethodPost, "/listeners/1/move", "port="+strconv.Itoa(port))
+
+	if response.Code != http.StatusSeeOther {
+		t.Fatalf("second move status = %d, want %d", response.Code, http.StatusSeeOther)
+	}
+
+	response = serveWebRequest(t, handler, http.MethodPost, "/listeners/1/activate", "")
+
+	if response.Code != http.StatusSeeOther || !listener.Listening {
+		t.Fatalf("activate response = (%d, listening %t), want redirect and active", response.Code, listener.Listening)
+	}
+
+	response = serveWebRequest(t, handler, http.MethodPost, "/listeners/1/deactivate", "")
+
+	if response.Code != http.StatusSeeOther || listener.Listening {
+		t.Fatalf("deactivate response = (%d, listening %t), want redirect and inactive", response.Code, listener.Listening)
+	}
+}
+
+func TestWebInterfaceSendsListenerSnapshots(t *testing.T) {
+	previousManager := localListeners
+	localListeners = newListenerManager()
+
+	defer func() { localListeners = previousManager }()
+
+	handler, err := newWebHandler()
+	if err != nil {
+		t.Fatalf("creating web handler: %v", err)
+	}
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/events"
+
+	conn, err := websocket.Dial(wsURL, "", server.URL)
+	if err != nil {
+		t.Fatalf("connecting to events websocket: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	var initial string
+
+	if err := websocket.Message.Receive(conn, &initial); err != nil {
+		t.Fatalf("receiving initial snapshot: %v", err)
+	}
+
+	if !strings.Contains(initial, "No listeners are registered.") {
+		t.Fatalf("initial snapshot = %q, want empty listener message", initial)
+	}
+
+	if _, created := localListeners.add(ft.Listener{Exp: "experiment", VM: "vm", SrcPort: 12345}); !created {
+		t.Fatal("listener was not created")
+	}
+
+	broadcastWebListeners()
+
+	var update string
+
+	if err := websocket.Message.Receive(conn, &update); err != nil {
+		t.Fatalf("receiving listener update: %v", err)
+	}
+
+	if !strings.Contains(update, "experiment") || !strings.Contains(update, "localhost:12345") {
+		t.Fatalf("listener update = %q, want one experiment listener", update)
+	}
+}
+
+func TestWebInterfaceReportsInvalidListenerActions(t *testing.T) {
+	previousManager := localListeners
+	localListeners = newListenerManager()
+	defer func() { localListeners = previousManager }()
+
+	handler, err := newWebHandler()
+	if err != nil {
+		t.Fatalf("creating web handler: %v", err)
+	}
+
+	tests := []struct {
+		path string
+		form string
+		want string
+	}{
+		{path: "/listeners/nope/activate", want: "malformed listener ID"},
+		{path: "/listeners/1/activate", want: "listener 1 not found"},
+		{path: "/listeners/1/move", form: "port=0", want: "listener port must be between 1 and 65535: 0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			response := serveWebRequest(t, handler, http.MethodPost, test.path, test.form)
+
+			if response.Code != http.StatusBadRequest && response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want bad request or not found", response.Code)
+			}
+
+			if !strings.Contains(response.Body.String(), test.want) {
+				t.Fatalf("response does not contain %q", test.want)
+			}
+		})
+	}
+}
+
+func serveWebRequest(t *testing.T, handler http.Handler, method, path, form string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	request := httptest.NewRequest(method, path, strings.NewReader(form))
+
+	if form != "" {
+		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+	return response
+}

--- a/src/js/src/views/Tunneler.vue
+++ b/src/js/src/views/Tunneler.vue
@@ -32,6 +32,14 @@
         <br />
         <br />
 
+        The <code>phenix-tunneler serve</code> command can also provide a local
+        web interface for listing and managing listeners. It is disabled by
+        default; enable it with the <code>--web-listen 127.0.0.1:8080</code>
+        flag (the address or port can be changed if needed).
+
+        <br />
+        <br />
+
         Once the phenix-tunneler server is running locally, it will
         automatically get notified of port forwards created in the UI. If the
         same user that logged into the phenix-tunneler server is the same user


### PR DESCRIPTION
# Pull Request Title

## Description
**Tunneler Web Interface**: Add a local web dashboard for listing, enabling, disabling, and moving listeners, with live WebSocket updates.

In addition, this PR also includes the following fixes for Tunneler:
- **Listener State Synchronization**: Centralized local listener tracking behind a synchronized manager to prevent concurrent map and state access.
- **Operation Reporting**: Return errors for unknown listeners and local port conflicts instead of reporting successful operations.
- **Argument Handling**: Reject malformed command arguments and Unix socket payloads without panicking.
- **Listener Moves**: Restore an active listener's original port when moving to a new port fails.
- **Listener IDs**: Maintain a direct ID index and prevent IDs from being reused during a tunneler session.
- **Listener Listing**: Return local listeners in deterministic ID order.
- **Duplicate Listeners**: Treat repeated listener creation events as idempotent without replacing active listeners.
- **Unix Socket Protocol**: Replace Gob messages with JSON and typed listener action payloads.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A